### PR TITLE
Feature: enforce type safety in dependants

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/example export-ignore
 /test export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@
 .gitignore export-ignore
 .travis.yml export-ignore
 phpunit.xml.dist export-ignore
-infection.json.dist
+infection.json.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/test export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore
+infection.json.dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/example/roave-you-are-using-it-wrong
 /coverage
 /vendor
 /clover.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/coverage
 /vendor
 /clover.xml
 /infection-log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/vendor
+/clover.xml
+/infection-log.txt
+/phpcs.xml
+/.phpcs-cache
+composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,6 @@ php:
   - '7.4snapshot'
   - 'nightly'
 
-jobs:
-  include:
-    - stage: Test
-      php: '7.3'
-      script: vendor/bin/phpunit --coverage-text
-
-    - stage: Static Analysis (src) with Psalm
-      php: '7.3'
-      script: vendor/bin/psalm
-
-    - stage: Coding Standards
-      php: '7.3'
-      script: vendor/bin/phpcs
-
-    - stage: Mutation Tests
-      php: '7.3'
-      script: vendor/bin/infection --min-msi=80 --min-covered-msi=100
-
 env:
   - DEPENDENCIES=""
   - DEPENDENCIES="--prefer-lowest --prefer-stable"
@@ -39,10 +21,10 @@ matrix:
 
 before_script:
   - git checkout -b built-ci-branch
-  - composer self-update
   - composer update --prefer-dist $DEPENDENCIES
 
 script:
-  - ./vendor/bin/phpunit --disallow-test-output --coverage-clover ./clover.xml
-  - if [[ $TRAVIS_PHP_VERSION = '7.3' && $DEPENDENCIES = '' ]]; then ./vendor/bin/infection; fi
-  - if [[ $TRAVIS_PHP_VERSION = '7.3' && $DEPENDENCIES = '' ]]; then ./vendor/bin/phpcs; fi
+  - vendor/bin/phpunit --coverage-text
+  - vendor/bin/psalm
+  - vendor/bin/phpcs
+  - vendor/bin/infection --min-msi=80 --min-covered-msi=100

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ script:
   - vendor/bin/phpunit --coverage-text --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml
   - vendor/bin/psalm
   - vendor/bin/phpcs
-  - vendor/bin/infection --min-msi=80 --min-covered-msi=100 --coverage=coverage
+  - vendor/bin/infection --min-msi=80 --min-covered-msi=100 --coverage=coverage --log-verbosity=none -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: php
+
+sudo: false
+
+php:
+  - '7.3'
+  - '7.4snapshot'
+  - 'nightly'
+
+env:
+  - DEPENDENCIES=""
+  - DEPENDENCIES="--prefer-lowest --prefer-stable"
+
+matrix:
+  allow_failures:
+  - php: '7.4snapshot'
+  - php: 'nightly'
+
+before_script:
+  - composer self-update
+  - composer update --prefer-dist $DEPENDENCIES
+
+script:
+  - ./vendor/bin/phpunit --disallow-test-output --coverage-clover ./clover.xml
+  - if [[ $TRAVIS_PHP_VERSION = '7.3' && $DEPENDENCIES = '' ]]; then ./vendor/bin/infection; fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.3' && $DEPENDENCIES = '' ]]; then ./vendor/bin/phpcs; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
 
     - stage: Mutation Tests
       php: '7.3'
-      script: vendor/bin/infection --min-msi=100 --min-covered-msi=100
+      script: vendor/bin/infection --min-msi=70 --min-covered-msi=100
 
 env:
   - DEPENDENCIES=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,24 @@ php:
   - '7.4snapshot'
   - 'nightly'
 
+jobs:
+  include:
+    - stage: Test
+      php: '7.3'
+      script: vendor/bin/phpunit --coverage-text
+
+    - stage: Static Analysis (src) with Psalm
+      php: '7.3'
+      script: vendor/bin/psalm
+
+    - stage: Coding Standards
+      php: '7.3'
+      script: vendor/bin/phpcs
+
+    - stage: Mutation Tests
+      php: '7.3'
+      script: vendor/bin/infection --min-msi=100 --min-covered-msi=100
+
 env:
   - DEPENDENCIES=""
   - DEPENDENCIES="--prefer-lowest --prefer-stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ script:
   - vendor/bin/psalm
   - vendor/bin/phpcs
   - vendor/bin/infection --min-msi=80 --min-covered-msi=100 --coverage=coverage --log-verbosity=none -s
+  - cd example && ./run-example.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
 
     - stage: Mutation Tests
       php: '7.3'
-      script: vendor/bin/infection --min-msi=70 --min-covered-msi=100
+      script: vendor/bin/infection --min-msi=80 --min-covered-msi=100
 
 env:
   - DEPENDENCIES=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ script:
   - vendor/bin/phpunit --coverage-text --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml
   - vendor/bin/psalm
   - vendor/bin/phpcs
-  - vendor/bin/infection --min-msi=80 --min-covered-msi=100 --coverage=coverage --log-verbosity=none -s
+  - vendor/bin/infection --min-msi=77 --min-covered-msi=100 --coverage=coverage --log-verbosity=none -s
   - cd example && ./run-example.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - composer update --prefer-dist $DEPENDENCIES
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - vendor/bin/phpunit --coverage-text --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml
   - vendor/bin/psalm
   - vendor/bin/phpcs
-  - vendor/bin/infection --min-msi=80 --min-covered-msi=100
+  - vendor/bin/infection --min-msi=80 --min-covered-msi=100 --coverage=coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 
 sudo: false
 
+git:
+  depth: false
+
 php:
   - '7.3'
   - '7.4snapshot'
@@ -35,6 +38,7 @@ matrix:
   - php: 'nightly'
 
 before_script:
+  - git checkout -b built-ci-branch
   - composer self-update
   - composer update --prefer-dist $DEPENDENCIES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# CHANGELOG
+
+## 1.0.0 - TBD

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019 Roave, LLC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Assuming you have a library with following `composer.json`:
 Given following `src/MyHelloWorld.php`:
 
 ```php
-<?php
+<?php declare(strict_types=1);
 
 namespace My\AwesomeLibrary;
 
@@ -90,7 +90,7 @@ Considering following downstream project:
 And following `src/MyExample.php`:
 
 ```php
-<?php
+<?php declare(strict_types=1);
 
 // notice the simple type error
 echo \My\AwesomeLibrary\MyHelloWorld::sayHello(123);

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 TBD
 
 [![Build Status](https://travis-ci.org/roave/you-are-using-it-wrong.svg?branch=master)](https://travis-ci.org/roave/you-are-using-it-wrong)
-[![Downloads](https://img.shields.io/packagist/dt/roave/you-are-using-it-wrong.svg)](https://packagist.org/packages/roave/you-are-using-it-wrong)
 [![Packagist](https://img.shields.io/packagist/v/roave/you-are-using-it-wrong.svg)](https://packagist.org/packages/roave/you-are-using-it-wrong)
-[![Dependencies](https://tidelift.com/badges/github/packagist/roave%2Fyou-are-using-it-wrong)](https://tidelift.com/subscription/pkg/packagist-roave%2Fyou-are-using-it-wrong?utm_source=packagist-ocramius%2Fpackage-versions&utm_medium=readme)
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,121 @@
 # roave/you-are-using-it-wrong
 
-TBD
-
 [![Build Status](https://travis-ci.org/roave/you-are-using-it-wrong.svg?branch=master)](https://travis-ci.org/roave/you-are-using-it-wrong)
 [![Packagist](https://img.shields.io/packagist/v/roave/you-are-using-it-wrong.svg)](https://packagist.org/packages/roave/you-are-using-it-wrong)
 
+This package enforces type checks during composer installation in downstream
+consumers of your package.
+
+`roave/you-are-using-it-wrong` comes with a zero-configuration out-of-the-box
+setup.
+
+The usage of this plugin is highly endorsed for authors of new PHP libraries
+who appreciate the advantages of static types.
+
+This project is built with the hope that libraries with larger user-bases will
+raise awareness of type safety (or current lack thereof) in the PHP ecosystem.
+
+As annoying as it might sound, it is not uncommon for library maintainers to
+respond to support questions caused by lack of type checks in downstream
+projects. In addition to that, relying more on static types over runtime checks,
+it is possible to reduce code size and maintenance burden by strengthening the
+API boundaries of a library.
+
 ### Installation
 
-TBD
+This package is designed to be installed as a dependency of PHP **libraries**.
 
-### Use-cases
+In your library, add it to your
+`composer.json`:
 
-TBD
+```sh
+composer require roave/you-are-doing-it-wrong
+```
+
+No further changes are needed for this tool to start operating as per its
+design, if your declared types are already reflecting your library requirements.
+
+Please also note that this should **not** be used in `"require-dev"`, but
+specifically in `"require"` in order for the type checks to be applied to
+downstream consumers of your code.
+
+### Examples
+
+Assuming you have a library with following `composer.json`:
+
+```json
+{
+    "name": "my/awesome-library",
+    "type": "library",
+    "autoload": {
+        "psr-4": {
+            "My\\AwesomeLibrary\\": "src"
+        }
+    },
+    "require": {
+        "roave/you-are-doing-it-wrong": "@STABLE"
+    }
+}
+```
+
+Given following `src/MyHelloWorld.php`:
+
+```php
+<?php
+
+namespace My\AwesomeLibrary;
+
+final class MyHelloWorld
+{
+    public static function sayHello(string $name) : string
+    {
+        return 'Hello ' . $name . '!';
+    }
+}
+```
+
+Considering following downstream project:
+
+```json
+{
+    "name": "a/project",
+    "autoload": {
+        "psr-4": {
+            "The\\Project\\": "src"
+        }
+    }
+}
+```
+
+And following `src/MyExample.php`:
+
+```php
+<?php
+
+// notice the simple type error
+echo \My\AwesomeLibrary\MyHelloWorld::sayHello(123);
+```
+
+Then following command will fail with a type check error and description:
+
+```sh
+composer require my/awesome-library:^1.0.0
+```
+
+## Workarounds
+
+This package is designed to be quite invasive from a type-check perspective,
+but it will bail out of any checks if a [`psalm.xml`](https://psalm.dev/docs/configuration/)
+is detected in the root of your project. If that is the case, the tool assumes
+that the author of the project is already responsible for ensuring type-safety
+within their own domain, and therefore bails out without performing further
+checks.
+
+As mentioned above, the design of the tool circles around raising awareness of
+static type usage in the PHP ecosystem, and therefore it will only give up if
+it is sure that you are already taking care of the matter on your own.
 
 ## Professional Support
 
-
-If you need help with setting up this library in your project, you can contact us at team@roave.com for consulting/support.
+If you need help with setting up this library in your project, you can contact
+us at team@roave.com for consulting/support.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Packagist](https://img.shields.io/packagist/v/roave/you-are-using-it-wrong.svg)](https://packagist.org/packages/roave/you-are-using-it-wrong)
 
 This package enforces type checks during composer installation in downstream
-consumers of your package.
+consumers of your package. This only applies to usages of classes, properties, methods and functions declared within packages that directly depend on *you-are-using-it-wrong*.  Issues that the static analyser finds that do not relate to these namespaces will not be reported.
 
 `roave/you-are-using-it-wrong` comes with a zero-configuration out-of-the-box
 setup.

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         "vimeo/psalm":               "dev-master"
     },
     "require-dev": {
-        "phpunit/phpunit":          "^8.0.0",
-        "infection/infection":      "^0.12.2",
         "composer/composer":        "^1.8.5",
         "doctrine/coding-standard": "^6.0.0",
-        "symfony/process":          "^4.2.8",
-        "psalm/plugin-phpunit": "^0.5.5"
+        "infection/infection":      "^0.12.2",
+        "phpunit/phpunit":          "^8.0.0",
+        "psalm/plugin-phpunit":     "^0.5.5",
+        "symfony/process":          "^4.2.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,44 @@
+{
+    "name": "roave/you-are-using-it-wrong",
+    "description": "Composer plugin enforcing strict type checks in downstream package dependants",
+    "type": "composer-plugin",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Marco Pivetta",
+            "email": "ocramius@gmail.com"
+        }
+    ],
+    "require": {
+        "php":                       "^7.3.0",
+        "ext-json":                  "*",
+        "composer-plugin-api":       "^1.0.0",
+        "ocramius/package-versions": "^1.4.0",
+        "vimeo/psalm":               "dev-master"
+    },
+    "require-dev": {
+        "phpunit/phpunit":          "^8.0.0",
+        "infection/infection":      "^0.12.2",
+        "composer/composer":        "^1.8.5",
+        "doctrine/coding-standard": "^6.0.0",
+        "symfony/process":          "^4.2.8"
+    },
+    "autoload": {
+        "psr-4": {
+            "Roave\\YouAreUsingItWrong\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "RoaveTest\\YouAreUsingItWrong\\": "test/unit",
+            "RoaveE2ETest\\YouAreUsingItWrong\\": "test/e2e"
+        }
+    },
+    "extra": {
+        "class": "Roave\\YouAreUsingItWrong\\Hook"
+    },
+    "scripts": {
+        "post-update-cmd":  "Roave\\YouAreUsingItWrong\\Hook::runTypeChecks",
+        "post-install-cmd": "Roave\\YouAreUsingItWrong\\Hook::runTypeChecks"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "infection/infection":      "^0.12.2",
         "composer/composer":        "^1.8.5",
         "doctrine/coding-standard": "^6.0.0",
-        "symfony/process":          "^4.2.8"
+        "symfony/process":          "^4.2.8",
+        "psalm/plugin-phpunit": "^0.5.5"
     },
     "autoload": {
         "psr-4": {

--- a/example/a-project/composer.json
+++ b/example/a-project/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "a/project",
+    "description": "A project that depends on my/awesome-library, and has type-errors in it",
+    "license": "proprietary",
+    "autoload": {
+        "psr-4": {
+            "The\\Project\\": "src"
+        }
+    },
+    "minimum-stability": "dev",
+    "require": {
+        "my/awesome-library": "1.0.0"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../roave-you-are-using-it-wrong"
+        },
+        {
+            "type": "path",
+            "url": "../my-awesome-library"
+        }
+    ]
+}

--- a/example/a-project/composer.json
+++ b/example/a-project/composer.json
@@ -1,7 +1,8 @@
 {
     "name": "a/project",
-    "description": "A project that depends on my/awesome-library, and has type-errors in it",
+    "type": "project",
     "license": "proprietary",
+    "description": "A project that depends on my/awesome-library, and has type-errors in it",
     "autoload": {
         "psr-4": {
             "The\\Project\\": "src"

--- a/example/a-project/src/MyExample.php
+++ b/example/a-project/src/MyExample.php
@@ -1,0 +1,4 @@
+<?php declare(strict_types=1);
+
+// notice the simple type error
+echo \My\AwesomeLibrary\MyHelloWorld::sayHello([123, 456]);

--- a/example/my-awesome-library/composer.json
+++ b/example/my-awesome-library/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "my/awesome-library",
+    "license": "MIT",
+    "description": "An example library, protected by roave/you-are-using-it-wrong",
+    "type": "library",
+    "version": "1.0.0",
+    "autoload": {
+        "psr-4": {
+            "My\\AwesomeLibrary\\": "src"
+        }
+    },
+    "require": {
+        "roave/you-are-using-it-wrong": "@CURRENT_ROAVE_DEV_VERSION"
+    }
+}

--- a/example/my-awesome-library/composer.json
+++ b/example/my-awesome-library/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "my/awesome-library",
+    "type": "library",
     "license": "MIT",
     "description": "An example library, protected by roave/you-are-using-it-wrong",
-    "type": "library",
     "version": "1.0.0",
     "autoload": {
         "psr-4": {

--- a/example/my-awesome-library/src/MyHelloWorld.php
+++ b/example/my-awesome-library/src/MyHelloWorld.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace My\AwesomeLibrary;
+
+final class MyHelloWorld
+{
+    /** @param array<string> $people */
+    public static function sayHello(array $people) : string
+    {
+        return 'Hello ' . implode(', ', $people) . '!';
+    }
+}

--- a/example/run-example.sh
+++ b/example/run-example.sh
@@ -5,10 +5,10 @@ set -euxo pipefail
 CURRENT_ROAVE_DEV_VERSION=$(git rev-parse --abbrev-ref HEAD)
 
 # The local version of the repository is not the stable/released one:
+git checkout -- my-awesome-library/composer.json
 sed -i s~@CURRENT_ROAVE_DEV_VERSION~dev-$CURRENT_ROAVE_DEV_VERSION~g my-awesome-library/composer.json
 
 # Composer cannot install a source package in itself, so we make a copy:
-git checkout -- my-awesome-library/composer.json
 rm -rf ./a-project/composer.lock
 rm -rf ./a-project/vendor
 rm -rf ./roave-you-are-using-it-wrong

--- a/example/run-example.sh
+++ b/example/run-example.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+CURRENT_ROAVE_DEV_VERSION=$(git rev-parse --abbrev-ref HEAD)
+
+# The local version of the repository is not the stable/released one:
+sed -i s~@CURRENT_ROAVE_DEV_VERSION~dev-$CURRENT_ROAVE_DEV_VERSION~g my-awesome-library/composer.json
+
+# Composer cannot install a source package in itself, so we make a copy:
+git checkout -- my-awesome-library/composer.json
+rm -rf ./a-project/composer.lock
+rm -rf ./a-project/vendor
+rm -rf ./roave-you-are-using-it-wrong
+cp -r ./.. /tmp/roave-you-are-using-it-wrong-example
+mv /tmp/roave-you-are-using-it-wrong-example ./roave-you-are-using-it-wrong
+
+cd a-project
+set +e
+
+# This command should fail with something like following:
+# > Argument 1 of My\AwesomeLibrary\MyHelloWorld::sayhello expects
+# > array<array-key, string>, array{0:int(123), 1:int(456)} provided
+composer install && exit 1 || exit 0

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,11 @@
+{
+    "timeout": 10,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "infection-log.txt"
+    }
+}

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -5,6 +5,9 @@
             "src"
         ]
     },
+    "mutators": {
+        "@default": true
+    },
     "logs": {
         "text": "infection-log.txt"
     }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ruleset
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+
+    <arg value="nps"/>
+
+    <file>src</file>
+    <file>test</file>
+
+    <rule ref="Doctrine"/>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="./vendor/autoload.php"
+    colors="true"
+    verbose="true"
+    columns="max"
+    beStrictAboutCoversAnnotation="true"
+    beStrictAboutResourceUsageDuringSmallTests="true"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTodoAnnotatedTests="true"
+>
+    <testsuites>
+        <testsuite name="Roave\YouAreUsingItWrong tests">
+            <directory>./test/unit</directory>
+        </testsuite>
+        <testsuite name="Roave\YouAreUsingItWrong e2e tests">
+            <directory>./test/e2e</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTodoAnnotatedTests="true"
+    executionOrder="random"
 >
     <testsuites>
         <testsuite name="Roave\YouAreUsingItWrong tests">

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<psalm
+    xmlns="https://getpsalm.org/schema/config"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    name="Example Psalm config with recommended defaults"
+    useDocblockTypes="true"
+    totallyTyped="false"
+    allowPhpStormGenerics="true"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="test/e2e"/>
+        <directory name="test/unit"/>
+    </projectFiles>
+
+    <issueHandlers>
+        <PropertyNotSetInConstructor errorLevel="suppress"/>
+        <InternalClass errorLevel="suppress"/>
+        <InternalMethod errorLevel="suppress"/>
+        <UnresolvableInclude errorLevel="suppress"/>
+    </issueHandlers>
+
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Roave\YouAreUsingItWrong\Composer;
 
+use function array_keys;
+use function in_array;
+
 /** @internal this class is only for supporting internal usage of locker data */
 final class Package
 {
@@ -30,10 +33,10 @@ final class Package
      *
      * @psalm-param array{
      *   name: string,
-     *   require: null|array<string, string>,
-     *   autoload: null|array{
-     *    psr-4: null|array<string, string|array<int, string>>,
-     *    psr-0: null|array<string, string|array<int, string>>
+     *   require?: array<string, string>,
+     *   autoload?: array{
+     *    psr-4?: array<string, string|array<int, string>>,
+     *    psr-0?: array<string, string|array<int, string>>
      *   }
      *  } $packageDefinition
      */

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\YouAreUsingItWrong\Composer;
+
+/** @internal this class is only for supporting internal usage of locker data */
+final class Package
+{
+    private const THIS_PACKAGE_NAME = 'roave/enforce-type-checks';
+
+    /** @var string */
+    private $name;
+
+    /** @var PackageAutoload */
+    private $autoload;
+
+    /** @var string[] */
+    private $dependencies;
+
+    private function __construct(string $name, PackageAutoload $autoload, string ...$dependencies)
+    {
+        $this->name         = $name;
+        $this->autoload     = $autoload;
+        $this->dependencies = $dependencies;
+    }
+
+    /**
+     * @param mixed[] $packageDefinition
+     *
+     * @psalm-param array{
+     *   name: string,
+     *   require: null|array<string, string>,
+     *   autoload: null|array{
+     *    psr-4: null|array<string, string|array<int, string>>,
+     *    psr-0: null|array<string, string|array<int, string>>
+     *   }
+     *  } $packageDefinition
+     */
+    public static function fromPackageDefinition(array $packageDefinition, string $installationPath) : self
+    {
+        return new self(
+            $packageDefinition['name'],
+            PackageAutoload::fromAutoloadDefinition($packageDefinition['autoload'] ?? [], $installationPath),
+            ...array_keys($packageDefinition['require'] ?? [])
+        );
+    }
+
+    public function name() : string
+    {
+        return $this->name;
+    }
+
+    public function autoload() : PackageAutoload
+    {
+        return $this->autoload;
+    }
+
+    public function requiresStrictChecks() : bool
+    {
+        return in_array(self::THIS_PACKAGE_NAME, $this->dependencies, true);
+    }
+}

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -10,7 +10,7 @@ use function in_array;
 /** @internal this class is only for supporting internal usage of locker data */
 final class Package
 {
-    private const THIS_PACKAGE_NAME = 'roave/enforce-type-checks';
+    private const THIS_PACKAGE_NAME = 'roave/you-are-using-it-wrong';
 
     /** @var string */
     private $name;

--- a/src/Composer/PackageAutoload.php
+++ b/src/Composer/PackageAutoload.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\YouAreUsingItWrong\Composer;
+
+use Composer\Package\RootPackageInterface;
+
+/** @internal this class is only for supporting internal usage of composer json data */
+final class PackageAutoload
+{
+    /** @var array */
+    private $psr4;
+
+    /** @var array */
+    private $psr0;
+
+    /** @var array */
+    private $classMap;
+
+    /** @var array */
+    private $files;
+
+    /**
+     * @param array<string, array<int, string>> $psr4
+     * @param array<string, array<int, string>> $psr0
+     * @param array<int, string>                $classMap
+     * @param array<int, string>                $files
+     */
+    private function __construct(
+        array $psr4,
+        array $psr0,
+        array $classMap,
+        array $files
+    ) {
+        $this->psr4     = $psr4;
+        $this->psr0     = $psr0;
+        $this->classMap = $classMap;
+        $this->files    = $files;
+    }
+
+    /**
+     * @param mixed[] $autoloadDefinition
+     *
+     * @psalm-param array{
+     *   psr-4: null|array<string, string|array<int, string>>,
+     *   psr-0: null|array<string, string|array<int, string>>,
+     *   files: null|array<int, string>,
+     *   classmap: null|array<int, string>
+     * } $autoloadDefinition
+     */
+    public static function fromAutoloadDefinition(array $autoloadDefinition, string $packageDirectory) : self
+    {
+        $prefixWithCurrentDir = static function (string $path) use ($packageDirectory) : string {
+            return $packageDirectory . '/' . $path;
+        };
+
+        return new self(
+            array_map(static function ($paths) use ($prefixWithCurrentDir) : array {
+                return array_map($prefixWithCurrentDir, array_map('strval', (array) $paths));
+            }, $autoloadDefinition['psr-4'] ?? []),
+            array_map(static function ($paths) use ($prefixWithCurrentDir) : array {
+                return array_map($prefixWithCurrentDir, array_map('strval', (array) $paths));
+            }, $autoloadDefinition['psr-0'] ?? []),
+            array_map($prefixWithCurrentDir, $autoloadDefinition['classmap'] ?? []),
+            array_map($prefixWithCurrentDir, $autoloadDefinition['files'] ?? [])
+        );
+    }
+
+    public static function fromComposerRootPackage(RootPackageInterface $package, string $projectDirectory) : self
+    {
+        /**
+         * @psalm-var array{
+         *   psr-4: null|array<string, string|array<int, string>>,
+         *   psr-0: null|array<string, string|array<int, string>>,
+         *   classmap: null|array<int, string>,
+         *   files: null|array<int, string>
+         * } $autoload
+         */
+        $autoload = $package->getAutoload();
+
+        return self::fromAutoloadDefinition($autoload, $projectDirectory);
+    }
+
+    /** @return array<int, string> */
+    public function directories() : array
+    {
+        return array_filter(array_map('realpath', array_merge(
+            [],
+            array_filter($this->classMap, 'is_dir'),
+            ...array_values($this->psr0),
+            ...array_values($this->psr4)
+        )));
+    }
+
+    /** @return array<int, string> */
+    public function files() : array
+    {
+        return array_filter(array_map('realpath', array_merge(
+            [],
+            array_filter($this->classMap, 'is_file'),
+            $this->files
+        )));
+    }
+
+    public function namespaces() : array
+    {
+        return array_merge(array_keys($this->psr4), array_keys($this->psr0));
+    }
+}

--- a/src/Composer/PackagesRequiringStrictChecks.php
+++ b/src/Composer/PackagesRequiringStrictChecks.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\YouAreUsingItWrong\Composer;
+
+use Composer\Package\Locker;
+
+/** @internal this class is only for supporting internal usage of locker data */
+final class PackagesRequiringStrictChecks
+{
+    /** @var Package[] */
+    private $packages;
+
+    private function __construct(Package ...$packages)
+    {
+        $this->packages = $packages;
+    }
+
+    public static function fromComposerLocker(Locker $locker, string $projectInstallationPath) : self
+    {
+        /**
+         * @var array{
+         *  packages: array<int, array{
+         *   name: string,
+         *   require: null|array<string, string>,
+         *   autoload: null|array{
+         *    psr-4: null|array<string, string|array<int, string>>,
+         *    psr-0: null|array<string, string|array<int, string>>
+         *   }
+         *  }>,
+         *  packages-dev: null|array<int, array{
+         *   name: string,
+         *   require: null|array<string, string>,
+         *   autoload: null|array{
+         *    psr-4: null|array<string, string|array<int, string>>,
+         *    psr-0: null|array<string, string|array<int, string>>
+         *   }
+         *  }>
+         * } $lockData
+         */
+        $lockData = $locker->getLockData();
+
+        return new self(...array_filter(
+            array_map(
+                function (array $packageDefinition) use ($projectInstallationPath) : Package {
+                    return Package::fromPackageDefinition(
+                        $packageDefinition,
+                        $projectInstallationPath . '/vendor/' . $packageDefinition['name']
+                    );
+                },
+                array_merge($lockData['packages'], $lockData['packages-dev'] ?? [])
+            ),
+            static function (Package $package) : bool {
+                return $package->requiresStrictChecks();
+            }
+        ));
+    }
+
+    /** @return array<int, string> */
+    public function packagesForWhichUsagesAreToBeTypeChecked() : array
+    {
+        return array_map(static function (Package $package) : string {
+            return $package->name();
+        }, $this->packages);
+    }
+
+    /** @return array<int, string> */
+    public function namespacesForWhichUsagesAreToBeTypeChecked() : array
+    {
+        return array_merge([], ...array_map(static function (Package $package) : array {
+            return $package
+                ->autoload()
+                ->namespaces();
+        }, $this->packages));
+    }
+}

--- a/src/Composer/PackagesRequiringStrictChecks.php
+++ b/src/Composer/PackagesRequiringStrictChecks.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Roave\YouAreUsingItWrong\Composer;
 
 use Composer\Package\Locker;
+use function array_filter;
+use function array_map;
+use function array_merge;
 
 /** @internal this class is only for supporting internal usage of locker data */
 final class PackagesRequiringStrictChecks
@@ -23,18 +26,18 @@ final class PackagesRequiringStrictChecks
          * @var array{
          *  packages: array<int, array{
          *   name: string,
-         *   require: null|array<string, string>,
-         *   autoload: null|array{
-         *    psr-4: null|array<string, string|array<int, string>>,
-         *    psr-0: null|array<string, string|array<int, string>>
+         *   require?: array<string, string>,
+         *   autoload?: array{
+         *    psr-4?: array<string, string|array<int, string>>,
+         *    psr-0?: array<string, string|array<int, string>>
          *   }
          *  }>,
-         *  packages-dev: null|array<int, array{
+         *  packages-dev?: array<int, array{
          *   name: string,
-         *   require: null|array<string, string>,
-         *   autoload: null|array{
-         *    psr-4: null|array<string, string|array<int, string>>,
-         *    psr-0: null|array<string, string|array<int, string>>
+         *   require?: array<string, string>,
+         *   autoload?: array{
+         *    psr-4?: array<string, string|array<int, string>>,
+         *    psr-0?: array<string, string|array<int, string>>
          *   }
          *  }>
          * } $lockData
@@ -43,7 +46,7 @@ final class PackagesRequiringStrictChecks
 
         return new self(...array_filter(
             array_map(
-                function (array $packageDefinition) use ($projectInstallationPath) : Package {
+                static function (array $packageDefinition) use ($projectInstallationPath) : Package {
                     return Package::fromPackageDefinition(
                         $packageDefinition,
                         $projectInstallationPath . '/vendor/' . $packageDefinition['name']

--- a/src/Composer/Project.php
+++ b/src/Composer/Project.php
@@ -6,6 +6,8 @@ namespace Roave\YouAreUsingItWrong\Composer;
 
 use Composer\Package\Locker;
 use Composer\Package\RootPackageInterface;
+use function array_filter;
+use function array_merge;
 
 /** @internal this class is only for supporting internal usage of locker data */
 final class Project
@@ -36,7 +38,7 @@ final class Project
         Locker $locker,
         string $currentWorkingDirectory
     ) : self {
-        /** @var array{packages: array<int, array{name: string}>, packages-dev: null|array<int, array{name: string}>} $lockData */
+        /** @psalm-var array{packages: array<int, array{name: string}>, packages-dev?: array<int, array{name: string}>} $lockData */
         $lockData = $locker->getLockData();
 
         return new self(

--- a/src/Composer/Project.php
+++ b/src/Composer/Project.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\YouAreUsingItWrong\Composer;
+
+use Composer\Package\Locker;
+use Composer\Package\RootPackageInterface;
+
+/** @internal this class is only for supporting internal usage of locker data */
+final class Project
+{
+    private const THIS_PACKAGE_NAME = 'roave/enforce-type-checks';
+
+    /** @var PackageAutoload */
+    private $rootPackageAutoload;
+
+    /** @var PackagesRequiringStrictChecks */
+    private $packagesRequiringStrictTypeChecks;
+
+    /** @var bool */
+    private $strictTypeChecksAreEnforcedByLocalInstallation;
+
+    private function __construct(
+        PackageAutoload $rootPackageAutoload,
+        PackagesRequiringStrictChecks $packagesRequiringStrictChecks,
+        bool $strictTypeChecksAreEnforcedByLocalInstallation
+    ) {
+        $this->rootPackageAutoload                            = $rootPackageAutoload;
+        $this->packagesRequiringStrictTypeChecks              = $packagesRequiringStrictChecks;
+        $this->strictTypeChecksAreEnforcedByLocalInstallation = $strictTypeChecksAreEnforcedByLocalInstallation;
+    }
+
+    public static function fromComposerInstallationContext(
+        RootPackageInterface $rootPackage,
+        Locker $locker,
+        string $currentWorkingDirectory
+    ) : self {
+        /** @var array{packages: array<int, array{name: string}>, packages-dev: null|array<int, array{name: string}>} $lockData */
+        $lockData = $locker->getLockData();
+
+        return new self(
+            PackageAutoload::fromComposerRootPackage($rootPackage, $currentWorkingDirectory),
+            PackagesRequiringStrictChecks::fromComposerLocker($locker, $currentWorkingDirectory),
+            array_filter(
+                array_merge($lockData['packages'], $lockData['packages-dev'] ?? []),
+                static function (array $package) : bool {
+                    return $package['name'] === self::THIS_PACKAGE_NAME;
+                }
+            ) !== []
+        );
+    }
+
+    public function rootPackageAutoload() : PackageAutoload
+    {
+        return $this->rootPackageAutoload;
+    }
+
+    public function packagesRequiringStrictTypeChecks() : PackagesRequiringStrictChecks
+    {
+        return $this->packagesRequiringStrictTypeChecks;
+    }
+
+    public function strictTypeChecksAreEnforcedByLocalInstallation() : bool
+    {
+        return $this->strictTypeChecksAreEnforcedByLocalInstallation;
+    }
+}

--- a/src/Composer/Project.php
+++ b/src/Composer/Project.php
@@ -8,6 +8,7 @@ use Composer\Package\Locker;
 use Composer\Package\RootPackageInterface;
 use function array_filter;
 use function array_merge;
+use function file_exists;
 
 /** @internal this class is only for supporting internal usage of locker data */
 final class Project
@@ -23,14 +24,19 @@ final class Project
     /** @var bool */
     private $strictTypeChecksAreEnforcedByLocalInstallation;
 
+    /** @var string */
+    private $projectDirectory;
+
     private function __construct(
         PackageAutoload $rootPackageAutoload,
         PackagesRequiringStrictChecks $packagesRequiringStrictChecks,
-        bool $strictTypeChecksAreEnforcedByLocalInstallation
+        bool $strictTypeChecksAreEnforcedByLocalInstallation,
+        string $projectDirectory
     ) {
         $this->rootPackageAutoload                            = $rootPackageAutoload;
         $this->packagesRequiringStrictTypeChecks              = $packagesRequiringStrictChecks;
         $this->strictTypeChecksAreEnforcedByLocalInstallation = $strictTypeChecksAreEnforcedByLocalInstallation;
+        $this->projectDirectory                               = $projectDirectory;
     }
 
     public static function fromComposerInstallationContext(
@@ -49,7 +55,8 @@ final class Project
                 static function (array $package) : bool {
                     return $package['name'] === self::THIS_PACKAGE_NAME;
                 }
-            ) !== []
+            ) !== [],
+            $currentWorkingDirectory
         );
     }
 
@@ -66,5 +73,10 @@ final class Project
     public function strictTypeChecksAreEnforcedByLocalInstallation() : bool
     {
         return $this->strictTypeChecksAreEnforcedByLocalInstallation;
+    }
+
+    public function alreadyHasOwnPsalmConfiguration() : bool
+    {
+        return file_exists($this->projectDirectory . '/psalm.xml');
     }
 }

--- a/src/Composer/Project.php
+++ b/src/Composer/Project.php
@@ -12,7 +12,7 @@ use function array_merge;
 /** @internal this class is only for supporting internal usage of locker data */
 final class Project
 {
-    private const THIS_PACKAGE_NAME = 'roave/enforce-type-checks';
+    private const THIS_PACKAGE_NAME = 'roave/you-are-using-it-wrong';
 
     /** @var PackageAutoload */
     private $rootPackageAutoload;

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -29,17 +29,13 @@ final class Hook implements PluginInterface, EventSubscriberInterface
 {
     private const THIS_PACKAGE_NAME = 'roave/you-are-using-it-wrong';
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     public function activate(Composer $composer, IOInterface $io) : void
     {
         // Nothing to do here, as all features are provided through event listeners
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     public static function getSubscribedEvents() : array
     {
         return [

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\YouAreUsingItWrong;
+
+use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\IO\IOInterface;
+use Composer\Package\Locker;
+use Composer\Package\RootPackageInterface;
+use Composer\Plugin\PluginInterface;
+use Composer\Script\Event;
+use Composer\Script\ScriptEvents;
+use PackageVersions\Versions;
+use Psalm\Config\ProjectFileFilter;
+use Psalm\Internal\Analyzer\ProjectAnalyzer;
+use Psalm\Internal\Provider\FileProvider;
+use Psalm\Internal\Provider\Providers;
+use Psalm\IssueBuffer;
+use Roave\YouAreUsingItWrong\Composer\PackageAutoload;
+use Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks;
+use Roave\YouAreUsingItWrong\Composer\Project;
+use Roave\YouAreUsingItWrong\Psalm\Configuration;
+use Roave\YouAreUsingItWrong\Psalm\ProjectFilesToBeTypeChecked;
+use RuntimeException;
+use function array_merge;
+
+/** @internal this is a composer plugin: do not rely on it in your sources */
+final class Hook implements PluginInterface, EventSubscriberInterface
+{
+    private const THIS_PACKAGE_NAME = 'roave/enforce-type-checks';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function activate(Composer $composer, IOInterface $io) : void
+    {
+        // Nothing to do here, as all features are provided through event listeners
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribedEvents() : array
+    {
+        return [
+            ScriptEvents::POST_INSTALL_CMD => 'runTypeChecks',
+            ScriptEvents::POST_UPDATE_CMD  => 'runTypeChecks',
+        ];
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    public static function runTypeChecks(Event $composerEvent) : void
+    {
+        $io       = $composerEvent->getIO();
+        $composer = $composerEvent->getComposer();
+        $project  = Project::fromComposerInstallationContext($composer->getPackage(), $composer->getLocker(), getcwd());
+
+        if (! $project->strictTypeChecksAreEnforcedByLocalInstallation()) {
+            $io->write('<info>' . self::THIS_PACKAGE_NAME . ':</info> plugin not installed locally - skipping type checks...');
+
+            return;
+        }
+
+        $io->write('<info>' . self::THIS_PACKAGE_NAME . ':</info> checking strictly type-checked packages...');
+
+        self::analyseProject($project);
+
+        $io->write('<info>' . self::THIS_PACKAGE_NAME . ':</info> ... done checking strictly type-checked packages');
+    }
+
+    private static function analyseProject(Project $project) : void
+    {
+        defined('PSALM_VERSION') || define('PSALM_VERSION', Versions::getVersion('vimeo/psalm'));
+        defined('PHP_PARSER_VERSION') || define('PHP_PARSER_VERSION', Versions::getVersion('nikic/php-parser'));
+
+        // At this stage of the installation, project dependencies are not yet autoloadable
+        require_once getcwd() . '/vendor/autoload.php';
+
+        $startTime = microtime(true);
+        // @TODO in project with psalm config, skip analysis: these people know what they are doing.
+
+        $files           = ProjectFilesToBeTypeChecked::fromAutoloadDefinitions($project->rootPackageAutoload());
+        $config          = Configuration::forStrictlyCheckedNamespacesAndProjectFiles(
+            $files,
+            ...$project
+            ->packagesRequiringStrictTypeChecks()
+            ->namespacesForWhichUsagesAreToBeTypeChecked()
+        );
+        $projectAnalyzer = new ProjectAnalyzer($config, new Providers(new FileProvider));
+
+        $config->visitComposerAutoloadFiles($projectAnalyzer);
+        $projectAnalyzer->check(__DIR__, false);
+
+        // NOTE: this calls exit(1) on failed checks - currently not a problem, but it may become one
+        IssueBuffer::finish($projectAnalyzer, true, $startTime);
+    }
+}

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -74,8 +74,13 @@ final class Hook implements PluginInterface, EventSubscriberInterface
 
     private static function analyseProject(Project $project) : void
     {
-        defined('PSALM_VERSION') || define('PSALM_VERSION', Versions::getVersion('vimeo/psalm'));
-        defined('PHP_PARSER_VERSION') || define('PHP_PARSER_VERSION', Versions::getVersion('nikic/php-parser'));
+        if (! defined('PSALM_VERSION')) {
+            define('PSALM_VERSION', Versions::getVersion('vimeo/psalm'));
+        }
+
+        if (! defined('PHP_PARSER_VERSION')) {
+            define('PHP_PARSER_VERSION', Versions::getVersion('nikic/php-parser'));
+        }
 
         // At this stage of the installation, project dependencies are not yet autoloadable
         require_once getcwd() . '/vendor/autoload.php';

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -64,7 +64,7 @@ final class Hook implements PluginInterface, EventSubscriberInterface
         }
 
         if ($project->alreadyHasOwnPsalmConfiguration()) {
-            $io->write('<info>' . self::THIS_PACKAGE_NAME . ':</info> psalm.xml detected - skipping static analysis, up to project maintainer to run it...');
+            $io->write('<info>' . self::THIS_PACKAGE_NAME . ':</info> psalm.xml detected - assuming static analysis will run later; not running psalm now');
 
             return;
         }

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -27,7 +27,7 @@ use function microtime;
 /** @internal this is a composer plugin: do not rely on it in your sources */
 final class Hook implements PluginInterface, EventSubscriberInterface
 {
-    private const THIS_PACKAGE_NAME = 'roave/enforce-type-checks';
+    private const THIS_PACKAGE_NAME = 'roave/you-are-using-it-wrong';
 
     /**
      * {@inheritDoc}

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -7,24 +7,22 @@ namespace Roave\YouAreUsingItWrong;
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
-use Composer\Package\Locker;
-use Composer\Package\RootPackageInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 use PackageVersions\Versions;
-use Psalm\Config\ProjectFileFilter;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\Provider\FileProvider;
 use Psalm\Internal\Provider\Providers;
 use Psalm\IssueBuffer;
-use Roave\YouAreUsingItWrong\Composer\PackageAutoload;
-use Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks;
 use Roave\YouAreUsingItWrong\Composer\Project;
 use Roave\YouAreUsingItWrong\Psalm\Configuration;
 use Roave\YouAreUsingItWrong\Psalm\ProjectFilesToBeTypeChecked;
 use RuntimeException;
-use function array_merge;
+use function define;
+use function defined;
+use function getcwd;
+use function microtime;
 
 /** @internal this is a composer plugin: do not rely on it in your sources */
 final class Hook implements PluginInterface, EventSubscriberInterface
@@ -90,7 +88,7 @@ final class Hook implements PluginInterface, EventSubscriberInterface
             ->packagesRequiringStrictTypeChecks()
             ->namespacesForWhichUsagesAreToBeTypeChecked()
         );
-        $projectAnalyzer = new ProjectAnalyzer($config, new Providers(new FileProvider));
+        $projectAnalyzer = new ProjectAnalyzer($config, new Providers(new FileProvider()));
 
         $config->visitComposerAutoloadFiles($projectAnalyzer);
         $projectAnalyzer->check(__DIR__, false);

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -63,6 +63,12 @@ final class Hook implements PluginInterface, EventSubscriberInterface
             return;
         }
 
+        if ($project->alreadyHasOwnPsalmConfiguration()) {
+            $io->write('<info>' . self::THIS_PACKAGE_NAME . ':</info> psalm.xml detected - skipping static analysis, up to project maintainer to run it...');
+
+            return;
+        }
+
         $io->write('<info>' . self::THIS_PACKAGE_NAME . ':</info> checking strictly type-checked packages...');
 
         self::analyseProject($project);

--- a/src/Psalm/Configuration.php
+++ b/src/Psalm/Configuration.php
@@ -12,6 +12,7 @@ use Psalm\Issue\CodeIssue;
 use Psalm\Issue\FunctionIssue;
 use Psalm\Issue\MethodIssue;
 use Psalm\Issue\PropertyIssue;
+use function stripos;
 
 /** @internal this class is only for configuring psalm according to the defaults of this repository */
 final class Configuration extends PsalmConfig
@@ -33,19 +34,19 @@ final class Configuration extends PsalmConfig
     public static function forStrictlyCheckedNamespacesAndProjectFiles(
         ProjectFileFilter $projectFileFilter,
         string ...$namespaces
-    ) {
+    ) : self {
         return new self($projectFileFilter, ...$namespaces);
     }
 
+    /** {@inheritDoc} */
     public function getReportingLevelForIssue(CodeIssue $e, array $suppressed_issues = []) : string
     {
-        if (
-            ($e instanceof ClassIssue && $this->identifierMatchesNamespace($e->fq_classlike_name))
+        if (($e instanceof ClassIssue && $this->identifierMatchesNamespace($e->fq_classlike_name))
             || ($e instanceof PropertyIssue && $this->identifierMatchesNamespace($e->property_id))
             || ($e instanceof MethodIssue && $this->identifierMatchesNamespace($e->method_id))
             || (
                 ($e instanceof FunctionIssue || $e instanceof ArgumentIssue)
-                && $this->identifierMatchesNamespace($e->function_id)
+                && $this->identifierMatchesNamespace((string) $e->function_id)
             )
         ) {
             return parent::getReportingLevelForIssue($e, $suppressed_issues);

--- a/src/Psalm/Configuration.php
+++ b/src/Psalm/Configuration.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\YouAreUsingItWrong\Psalm;
+
+use Psalm\Config as PsalmConfig;
+use Psalm\Config\ProjectFileFilter;
+use Psalm\Issue\ArgumentIssue;
+use Psalm\Issue\ClassIssue;
+use Psalm\Issue\CodeIssue;
+use Psalm\Issue\FunctionIssue;
+use Psalm\Issue\MethodIssue;
+use Psalm\Issue\PropertyIssue;
+
+/** @internal this class is only for configuring psalm according to the defaults of this repository */
+final class Configuration extends PsalmConfig
+{
+    /** @var string[] */
+    private $checkedNamespaces;
+
+    protected function __construct(ProjectFileFilter $files, string ...$checkedNamespaces)
+    {
+        parent::__construct();
+
+        $this->project_files           = $files;
+        $this->allow_phpstorm_generics = true;
+        $this->use_docblock_types      = true;
+        $this->totally_typed           = true;
+        $this->checkedNamespaces       = $checkedNamespaces;
+    }
+
+    public static function forStrictlyCheckedNamespacesAndProjectFiles(
+        ProjectFileFilter $projectFileFilter,
+        string ...$namespaces
+    ) {
+        return new self($projectFileFilter, ...$namespaces);
+    }
+
+    public function getReportingLevelForIssue(CodeIssue $e, array $suppressed_issues = []) : string
+    {
+        if (
+            ($e instanceof ClassIssue && $this->identifierMatchesNamespace($e->fq_classlike_name))
+            || ($e instanceof PropertyIssue && $this->identifierMatchesNamespace($e->property_id))
+            || ($e instanceof MethodIssue && $this->identifierMatchesNamespace($e->method_id))
+            || (
+                ($e instanceof FunctionIssue || $e instanceof ArgumentIssue)
+                && $this->identifierMatchesNamespace($e->function_id)
+            )
+        ) {
+            return parent::getReportingLevelForIssue($e, $suppressed_issues);
+        }
+
+        return self::REPORT_SUPPRESS;
+    }
+
+    private function identifierMatchesNamespace(string $identifier) : bool
+    {
+        foreach ($this->checkedNamespaces as $namespace) {
+            if (stripos($identifier, $namespace) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Psalm/ProjectFilesToBeTypeChecked.php
+++ b/src/Psalm/ProjectFilesToBeTypeChecked.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\YouAreUsingItWrong\Psalm;
+
+use Psalm\Config\ProjectFileFilter;
+use Roave\YouAreUsingItWrong\Composer\PackageAutoload;
+
+/** @internal this class is only for configuring psalm according to the defaults of this repository */
+final class ProjectFilesToBeTypeChecked extends ProjectFileFilter
+{
+    public function __construct($inclusive)
+    {
+        parent::__construct($inclusive);
+    }
+
+    public static function fromAutoloadDefinitions(PackageAutoload $autoload) : self
+    {
+        $instance = new self(true);
+
+        foreach ($autoload->directories() as $directory) {
+            $instance->addDirectory($directory);
+        }
+
+        foreach ($autoload->files() as $file) {
+            $instance->addFile($file);
+        }
+
+        return $instance;
+    }
+}

--- a/src/Psalm/ProjectFilesToBeTypeChecked.php
+++ b/src/Psalm/ProjectFilesToBeTypeChecked.php
@@ -10,7 +10,8 @@ use Roave\YouAreUsingItWrong\Composer\PackageAutoload;
 /** @internal this class is only for configuring psalm according to the defaults of this repository */
 final class ProjectFilesToBeTypeChecked extends ProjectFileFilter
 {
-    public function __construct($inclusive)
+    /** {@inheritDoc} */
+    public function __construct(bool $inclusive)
     {
         parent::__construct($inclusive);
     }

--- a/test/e2e/GenerateRepository.php
+++ b/test/e2e/GenerateRepository.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveE2ETest\YouAreUsingItWrong;
+
+use Symfony\Component\Process\Process;
+
+final class GenerateRepository
+{
+    private function __construct()
+    {
+    }
+
+    public static function generateRepository(string ...$dependencies) : string
+    {
+        $installationTargetPath = tempnam(sys_get_temp_dir(), 'test-installation-');
+
+        unlink($installationTargetPath);
+        mkdir($installationTargetPath);
+        mkdir($installationTargetPath . '/src');
+
+        $currentGitVersion = (new Process(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], __DIR__ . '/../..'))
+            ->mustRun()
+            ->getOutput();
+
+        file_put_contents(
+            $installationTargetPath . '/composer.json',
+            json_encode(
+                [
+                    'minimum-stability' => 'dev',
+                    'autoload'          => [
+                        'psr-4' => ['Project\\' => './src'],
+                    ],
+                    'require'           => array_merge(
+                        ['roave/enforce-type-checks' => 'dev-' . $currentGitVersion],
+                        ...array_map(function (string $dependency) use ($currentGitVersion) : array {
+                            return [$dependency => 'dev-' . $currentGitVersion];
+                        }, $dependencies)
+                    ),
+                    'repositories'      => array_merge(
+                        [
+                            // @NOTE: disabling packagist won't work because this repository has complex dependencies
+                            // that need to be looked up at very specific versions
+                            // ['packagist.org' => false],
+                        ],
+                        array_map(
+                            function (string $path) : array {
+                                return [
+                                    'type' => 'path',
+                                    'url'  => $path,
+                                ];
+                            },
+                            array_merge(
+                                array_filter(
+                                    array_map('realpath', glob(__DIR__ . '/../../vendor/*/*')),
+                                    'is_dir'
+                                ),
+                                [
+                                    realpath(__DIR__ . '/../..'),
+                                    realpath(__DIR__ . '/../repositories/empty-repository'),
+                                    realpath(__DIR__ . '/../repositories/project-with-violations'),
+                                    realpath(__DIR__ . '/../repositories/repository-depending-on-type-checks'),
+                                    realpath(__DIR__ . '/../repositories/repository-indirectly-depending-on-type-checks'),
+                                    realpath(__DIR__ . '/../repositories/repository-not-depending-on-type-checks'),
+                                ]
+                            )
+                        )
+                    ),
+                ],
+                JSON_PRETTY_PRINT
+            )
+        );
+
+        copy(
+            __DIR__ . '/../repositories/project-with-violations/src/file-with-violations.php',
+            $installationTargetPath . '/src/file-with-violations.php'
+        );
+
+        return $installationTargetPath;
+    }
+}

--- a/test/e2e/GenerateRepository.php
+++ b/test/e2e/GenerateRepository.php
@@ -46,7 +46,7 @@ final class GenerateRepository
                         'psr-4' => ['Project\\' => './src'],
                     ],
                     'require'           => array_merge(
-                        ['roave/enforce-type-checks' => 'dev-' . $currentGitVersion],
+                        ['roave/you-are-using-it-wrong' => 'dev-' . $currentGitVersion],
                         ...array_map(static function (string $dependency) use ($currentGitVersion) : array {
                             return [$dependency => 'dev-' . $currentGitVersion];
                         }, $dependencies)

--- a/test/e2e/SimulatedInstallationTest.php
+++ b/test/e2e/SimulatedInstallationTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveE2ETest\YouAreUsingItWrong;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+final class SimulatedInstallationTest extends TestCase
+{
+    /** @var string|null */
+    private $repository;
+
+    protected function tearDown() : void
+    {
+//        if ($this->repository !== null) {
+//            (new Process(['rm', '-r', $this->repository]))
+//                ->mustRun();
+//        }
+
+        parent::tearDown();
+    }
+
+    public function testRepositoryWithoutIssues() : void
+    {
+        $this->repository = GenerateRepository::generateRepository();
+
+        $command = (new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], $this->repository))
+            ->mustRun();
+
+        $output = $command->getOutput();
+
+        self::assertStringNotContainsString('No files analyzed', $output);
+        self::assertStringContainsString('checking strictly type-checked packages...', $output);
+        self::assertStringContainsString('No errors found!', $output);
+        self::assertStringContainsString('done checking strictly type-checked packages', $output);
+    }
+
+    public function testRepositoryWithDependenciesNotDependingOnStrictTypeChecksWillNotHaveIssuesRaised() : void
+    {
+        $this->repository = GenerateRepository::generateRepository('test/repository-not-depending-on-type-checks');
+
+        $command = (new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], $this->repository))
+            ->mustRun();
+
+        $output = $command->getOutput();
+
+        self::assertStringNotContainsString('No files analyzed', $output);
+        self::assertStringContainsString('checking strictly type-checked packages...', $output);
+        self::assertStringContainsString('No errors found!', $output);
+        self::assertStringContainsString('done checking strictly type-checked packages', $output);
+    }
+
+    public function testRepositoryReportsIssuesWhenDependingOnPackageThatEnforcesStrictTypeChecks() : void
+    {
+        $this->repository = GenerateRepository::generateRepository('test/repository-depending-on-type-checks');
+
+        $command = new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], $this->repository);
+
+        $command->run();
+
+        self::assertSame(1, $command->getExitCode());
+
+        $output = $command->getOutput();
+
+        self::assertStringContainsString('checking strictly type-checked packages...', $output);
+        self::assertStringContainsString('1 errors', $output);
+        self::assertStringContainsString(
+            'Argument 1 of Test\\RepositoryDependingOnTypeChecks\\SomeClass::amethod expects string, int(123) provided',
+            $output
+        );
+
+        self::assertStringNotContainsString('No errors found!', $output);
+        self::assertStringNotContainsString('done checking strictly type-checked packages', $output);
+    }
+
+    public function testRepositoryReportsIssuesWhenDependingIndirectlyOnPackageThatEnforcesStrictTypeChecks() : void
+    {
+        $this->repository = GenerateRepository::generateRepository('test/repository-indirectly-depending-on-type-checks');
+
+        $command = new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], $this->repository);
+
+        $command->run();
+
+        self::assertSame(1, $command->getExitCode());
+
+        $output = $command->getOutput();
+
+        self::assertStringContainsString('checking strictly type-checked packages...', $output);
+        self::assertStringContainsString('1 errors', $output);
+        self::assertStringContainsString(
+            'Argument 1 of Test\\RepositoryDependingOnTypeChecks\\SomeClass::amethod expects string, int(123) provided',
+            $output
+        );
+
+        self::assertStringNotContainsString('No errors found!', $output);
+        self::assertStringNotContainsString('done checking strictly type-checked packages', $output);
+    }
+
+    public function testRepositoryOnlyReportsIssuesOnDependencyUsagesThatEnforceStrictTypeChecks() : void
+    {
+        $this->repository = GenerateRepository::generateRepository(
+            'test/empty-repository',
+            'test/repository-depending-on-type-checks',
+            'test/repository-indirectly-depending-on-type-checks',
+            'test/repository-not-depending-on-type-checks',
+        );
+
+        $command = new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], $this->repository);
+
+        $command->run();
+
+        self::assertSame(1, $command->getExitCode());
+
+        $output = $command->getOutput();
+
+        self::assertStringContainsString('checking strictly type-checked packages...', $output);
+        self::assertStringContainsString('1 errors', $output);
+        self::assertStringContainsString(
+            'Argument 1 of Test\\RepositoryDependingOnTypeChecks\\SomeClass::amethod expects string, int(123) provided',
+            $output
+        );
+
+        self::assertStringNotContainsString('No errors found!', $output);
+        self::assertStringNotContainsString('done checking strictly type-checked packages', $output);
+    }
+}

--- a/test/repositories/empty-repository/composer.json
+++ b/test/repositories/empty-repository/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "test/empty-repository"
+}

--- a/test/repositories/project-with-violations/composer.json
+++ b/test/repositories/project-with-violations/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "test/project-with-violations",
+    "autoload": {
+        "psr-4": {
+            "Test\\ProjectWithViolations\\": "src"
+        }
+    }
+}

--- a/test/repositories/project-with-violations/src/file-with-violations.php
+++ b/test/repositories/project-with-violations/src/file-with-violations.php
@@ -1,5 +1,9 @@
 <?php
 
-var_dump((new \Test\RepositoryDependingOnTypeChecks\SomeClass())->aMethod(123));
+declare(strict_types=1);
+
+use Test\RepositoryDependingOnTypeChecks\SomeClass;
+
+var_dump((new SomeClass())->aMethod(123));
 var_dump((new \Test\RepositoryIndirectlyDependingOnTypeChecks\SomeClass())->aMethod(123));
 var_dump((new \Test\RepositoryNotDependingOnTypeChecks\SomeClass())->aMethod(123));

--- a/test/repositories/project-with-violations/src/file-with-violations.php
+++ b/test/repositories/project-with-violations/src/file-with-violations.php
@@ -1,0 +1,5 @@
+<?php
+
+var_dump((new \Test\RepositoryDependingOnTypeChecks\SomeClass())->aMethod(123));
+var_dump((new \Test\RepositoryIndirectlyDependingOnTypeChecks\SomeClass())->aMethod(123));
+var_dump((new \Test\RepositoryNotDependingOnTypeChecks\SomeClass())->aMethod(123));

--- a/test/repositories/repository-depending-on-type-checks/composer.json
+++ b/test/repositories/repository-depending-on-type-checks/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "test/repository-depending-on-type-checks",
+    "require": {
+        "roave/enforce-type-checks": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "Test\\RepositoryDependingOnTypeChecks\\": "src"
+        }
+    }
+}

--- a/test/repositories/repository-depending-on-type-checks/composer.json
+++ b/test/repositories/repository-depending-on-type-checks/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "test/repository-depending-on-type-checks",
     "require": {
-        "roave/enforce-type-checks": "*"
+        "roave/you-are-using-it-wrong": "*"
     },
     "autoload": {
         "psr-4": {

--- a/test/repositories/repository-depending-on-type-checks/src/SomeClass.php
+++ b/test/repositories/repository-depending-on-type-checks/src/SomeClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\RepositoryDependingOnTypeChecks;
+
+final class SomeClass
+{
+    public function aMethod(string $foo) : void
+    {
+    }
+}

--- a/test/repositories/repository-indirectly-depending-on-type-checks/composer.json
+++ b/test/repositories/repository-indirectly-depending-on-type-checks/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "test/repository-indirectly-depending-on-type-checks",
+    "require": {
+        "test/repository-depending-on-type-checks": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "Test\\RepositoryIndirectlyDependingOnTypeChecks\\": "src"
+        }
+    }
+}

--- a/test/repositories/repository-indirectly-depending-on-type-checks/src/SomeClass.php
+++ b/test/repositories/repository-indirectly-depending-on-type-checks/src/SomeClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\RepositoryIndirectlyDependingOnTypeChecks;
+
+final class SomeClass
+{
+    public function aMethod(string $foo) : void
+    {
+    }
+}

--- a/test/repositories/repository-not-depending-on-type-checks/composer.json
+++ b/test/repositories/repository-not-depending-on-type-checks/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "test/repository-not-depending-on-type-checks",
+    "autoload": {
+        "psr-4": {
+            "Test\\RepositoryNotDependingOnTypeChecks\\": "src"
+        }
+    }
+}

--- a/test/repositories/repository-not-depending-on-type-checks/src/SomeClass.php
+++ b/test/repositories/repository-not-depending-on-type-checks/src/SomeClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\RepositoryNotDependingOnTypeChecks;
+
+final class SomeClass
+{
+    public function aMethod(string $foo) : void
+    {
+    }
+}

--- a/test/unit/Composer/PackageAutoloadTest.php
+++ b/test/unit/Composer/PackageAutoloadTest.php
@@ -7,24 +7,34 @@ namespace RoaveTest\YouAreUsingItWrong\Composer;
 use Composer\Package\RootPackageInterface;
 use PHPUnit\Framework\TestCase;
 use Roave\YouAreUsingItWrong\Composer\PackageAutoload;
+use function realpath;
 
 /** @covers \Roave\YouAreUsingItWrong\Composer\PackageAutoload */
 final class PackageAutoloadTest extends TestCase
 {
-    /** @dataProvider expectedDirectories */
+    /**
+     * @param array<string, mixed> $autoloadDefinition
+     * @param array<int, string>   $expectedDirectories
+     *
+     * @dataProvider expectedDirectories
+     */
     public function testDirectoriesFromAutoloadDefinition(
         array $autoloadDefinition,
         array $expectedDirectories
     ) : void {
         self::assertSame(
             $expectedDirectories,
-            PackageAutoload
-                ::fromAutoloadDefinition($autoloadDefinition, realpath(__DIR__ . '/..'))
-                ->directories()
+            PackageAutoload::fromAutoloadDefinition($autoloadDefinition, realpath(__DIR__ . '/..'))
+                           ->directories()
         );
     }
 
-    /** @dataProvider expectedDirectories */
+    /**
+     * @param array<string, mixed> $autoloadDefinition
+     * @param array<int, string>   $expectedDirectories
+     *
+     * @dataProvider expectedDirectories
+     */
     public function testDirectoriesFromComposerRootPackage(
         array $autoloadDefinition,
         array $expectedDirectories
@@ -37,12 +47,19 @@ final class PackageAutoloadTest extends TestCase
 
         self::assertSame(
             $expectedDirectories,
-            PackageAutoload
-                ::fromComposerRootPackage($rootPackage, realpath(__DIR__ . '/..'))
-                ->directories()
+            PackageAutoload::fromComposerRootPackage($rootPackage, realpath(__DIR__ . '/..'))
+                           ->directories()
         );
     }
 
+    /**
+     * @return array<string, mixed>
+     *
+     * @psalm-return array<string, array{0: array{
+     *  psr-0?: array<string, string|array<int, string>>,
+     *  psr-4?: array<string, string|array<int, string>>
+     * }, 1: array<int, string>}>
+     */
     public function expectedDirectories() : array
     {
         return [
@@ -138,20 +155,29 @@ final class PackageAutoloadTest extends TestCase
         ];
     }
 
-    /** @dataProvider expectedFiles */
+    /**
+     * @param array<string, mixed> $autoloadDefinition
+     * @param array<int, string>   $expectedFiles
+     *
+     * @dataProvider expectedFiles
+     */
     public function testFilesFromAutoloadDefinition(
         array $autoloadDefinition,
         array $expectedFiles
     ) : void {
         self::assertSame(
             $expectedFiles,
-            PackageAutoload
-                ::fromAutoloadDefinition($autoloadDefinition, realpath(__DIR__ . '/..'))
-                ->files()
+            PackageAutoload::fromAutoloadDefinition($autoloadDefinition, realpath(__DIR__ . '/..'))
+                           ->files()
         );
     }
 
-    /** @dataProvider expectedFiles */
+    /**
+     * @param array<string, mixed> $autoloadDefinition
+     * @param array<int, string>   $expectedFiles
+     *
+     * @dataProvider expectedFiles
+     */
     public function testFilesFromComposerRootPackage(
         array $autoloadDefinition,
         array $expectedFiles
@@ -164,12 +190,16 @@ final class PackageAutoloadTest extends TestCase
 
         self::assertSame(
             $expectedFiles,
-            PackageAutoload
-                ::fromComposerRootPackage($rootPackage, realpath(__DIR__ . '/..'))
-                ->files()
+            PackageAutoload::fromComposerRootPackage($rootPackage, realpath(__DIR__ . '/..'))
+                           ->files()
         );
     }
 
+    /**
+     * @return array<string, mixed>
+     *
+     * @psalm-return array<string, array{0: array{classmap?: array<int, string>}, 1: array<int, string>}>
+     */
     public function expectedFiles() : array
     {
         return [
@@ -200,22 +230,29 @@ final class PackageAutoloadTest extends TestCase
         ];
     }
 
-
-    /** @dataProvider expectedNamespaces */
+    /**
+     * @param array<string, mixed> $autoloadDefinition
+     * @param array<int, string>   $expectedNamespaces
+     *
+     * @dataProvider expectedNamespaces
+     */
     public function testNamespacesFromAutoloadDefinition(
         array $autoloadDefinition,
         array $expectedNamespaces
     ) : void {
         self::assertSame(
             $expectedNamespaces,
-            PackageAutoload
-                ::fromAutoloadDefinition($autoloadDefinition, realpath(__DIR__ . '/..'))
-                ->namespaces()
+            PackageAutoload::fromAutoloadDefinition($autoloadDefinition, realpath(__DIR__ . '/..'))
+                           ->namespaces()
         );
     }
 
-
-    /** @dataProvider expectedNamespaces */
+    /**
+     * @param array<string, mixed> $autoloadDefinition
+     * @param array<int, string>   $expectedNamespaces
+     *
+     * @dataProvider expectedNamespaces
+     */
     public function testNamespacesFromRootPackage(
         array $autoloadDefinition,
         array $expectedNamespaces
@@ -228,12 +265,19 @@ final class PackageAutoloadTest extends TestCase
 
         self::assertSame(
             $expectedNamespaces,
-            PackageAutoload
-                ::fromComposerRootPackage($rootPackage, realpath(__DIR__ . '/..'))
-                ->namespaces()
+            PackageAutoload::fromComposerRootPackage($rootPackage, realpath(__DIR__ . '/..'))
+                           ->namespaces()
         );
     }
 
+    /**
+     * @return array<string, mixed>
+     *
+     * @psalm-return array<string, array{0: array{
+     *  psr-0?: array<string, string|array<int, string>>,
+     *  psr-4?: array<string, string|array<int, string>>
+     * }, 1: array<int, string>}>
+     */
     public function expectedNamespaces() : array
     {
         return [
@@ -300,7 +344,7 @@ final class PackageAutoloadTest extends TestCase
                     'Non_Existing_',
                     'Another_Ns_',
                 ],
-            ]
+            ],
         ];
     }
 }

--- a/test/unit/Composer/PackageAutoloadTest.php
+++ b/test/unit/Composer/PackageAutoloadTest.php
@@ -198,7 +198,10 @@ final class PackageAutoloadTest extends TestCase
     /**
      * @return array<string, mixed>
      *
-     * @psalm-return array<string, array{0: array{classmap?: array<int, string>}, 1: array<int, string>}>
+     * @psalm-return array<string, array{0: array{
+     *   classmap?: array<int, string>,
+     *   files?: array<int, string>
+     * }, 1: array<int, string>}>
      */
     public function expectedFiles() : array
     {
@@ -216,6 +219,20 @@ final class PackageAutoloadTest extends TestCase
             'definition with classmap pointing to file' => [
                 [
                     'classmap' => ['Composer/PackageAutoloadTest.php'],
+                ],
+                [
+                    realpath(__FILE__),
+                ],
+            ],
+            'definition with file pointing to non-existing file' => [
+                [
+                    'files' => ['non-existing'],
+                ],
+                [],
+            ],
+            'definition with file pointing to existing file' => [
+                [
+                    'files' => ['Composer/PackageAutoloadTest.php'],
                 ],
                 [
                     realpath(__FILE__),

--- a/test/unit/Composer/PackageAutoloadTest.php
+++ b/test/unit/Composer/PackageAutoloadTest.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\YouAreUsingItWrong\Composer;
+
+use Composer\Package\RootPackageInterface;
+use PHPUnit\Framework\TestCase;
+use Roave\YouAreUsingItWrong\Composer\PackageAutoload;
+
+/** @covers \Roave\YouAreUsingItWrong\Composer\PackageAutoload */
+final class PackageAutoloadTest extends TestCase
+{
+    /** @dataProvider expectedDirectories */
+    public function testDirectoriesFromAutoloadDefinition(
+        array $autoloadDefinition,
+        array $expectedDirectories
+    ) : void {
+        self::assertSame(
+            $expectedDirectories,
+            PackageAutoload
+                ::fromAutoloadDefinition($autoloadDefinition, realpath(__DIR__ . '/..'))
+                ->directories()
+        );
+    }
+
+    /** @dataProvider expectedDirectories */
+    public function testDirectoriesFromComposerRootPackage(
+        array $autoloadDefinition,
+        array $expectedDirectories
+    ) : void {
+        $rootPackage = $this->createMock(RootPackageInterface::class);
+
+        $rootPackage
+            ->method('getAutoload')
+            ->willReturn($autoloadDefinition);
+
+        self::assertSame(
+            $expectedDirectories,
+            PackageAutoload
+                ::fromComposerRootPackage($rootPackage, realpath(__DIR__ . '/..'))
+                ->directories()
+        );
+    }
+
+    public function expectedDirectories() : array
+    {
+        return [
+            'empty definition'                                    => [
+                [],
+                [],
+            ],
+            'definition with non-existing psr-4 single directory' => [
+                [
+                    'psr-4' => ['Non\\Existing\\' => 'foo'],
+                ],
+                [],
+            ],
+            'definition with non-existing psr-4 array directory'  => [
+                [
+                    'psr-4' => ['Non\\Existing\\' => ['foo']],
+                ],
+                [],
+            ],
+            'definition with existing psr-4 single directory'     => [
+                [
+                    'psr-4' => ['Non\\Existing\\' => 'Composer'],
+                ],
+                [
+                    realpath(__DIR__),
+                ],
+            ],
+            'definition with multiple existing psr-4 directories' => [
+                [
+                    'psr-4' => [
+                        'Non\\Existing\\' => 'Composer',
+                        'Another\\Ns\\'   => 'Psalm',
+                    ],
+                ],
+                [
+                    realpath(__DIR__),
+                    realpath(__DIR__ . '/../Psalm'),
+                ],
+            ],
+            'definition with non-existing psr-0 single directory' => [
+                [
+                    'psr-0' => ['Non_Existing_' => 'foo'],
+                ],
+                [],
+            ],
+            'definition with non-existing psr-0 array directory'  => [
+                [
+                    'psr-0' => ['Non_Existing_' => ['foo']],
+                ],
+                [],
+            ],
+            'definition with existing psr-0 single directory'     => [
+                [
+                    'psr-0' => ['Non_Existing_' => 'Composer'],
+                ],
+                [
+                    realpath(__DIR__),
+                ],
+            ],
+            'definition with multiple existing psr-0 directories' => [
+                [
+                    'psr-0' => [
+                        'Non_Existing_' => 'Composer',
+                        'Another_Ns_'   => 'Psalm',
+                    ],
+                ],
+                [
+                    realpath(__DIR__),
+                    realpath(__DIR__ . '/../Psalm'),
+                ],
+            ],
+            'definition with non-existing classmap'               => [
+                [
+                    'classmap' => ['non-existing'],
+                ],
+                [],
+            ],
+            'definition with classmap pointing to file'           => [
+                [
+                    'classmap' => ['Composer/PackageAutoloadTest.php'],
+                ],
+                [],
+            ],
+            'definition with directory classmap'                  => [
+                [
+                    'classmap' => ['Composer', 'Psalm'],
+                ],
+                [
+                    realpath(__DIR__),
+                    realpath(__DIR__ . '/../Psalm'),
+                ],
+            ],
+        ];
+    }
+
+    /** @dataProvider expectedFiles */
+    public function testFilesFromAutoloadDefinition(
+        array $autoloadDefinition,
+        array $expectedFiles
+    ) : void {
+        self::assertSame(
+            $expectedFiles,
+            PackageAutoload
+                ::fromAutoloadDefinition($autoloadDefinition, realpath(__DIR__ . '/..'))
+                ->files()
+        );
+    }
+
+    /** @dataProvider expectedFiles */
+    public function testFilesFromComposerRootPackage(
+        array $autoloadDefinition,
+        array $expectedFiles
+    ) : void {
+        $rootPackage = $this->createMock(RootPackageInterface::class);
+
+        $rootPackage
+            ->method('getAutoload')
+            ->willReturn($autoloadDefinition);
+
+        self::assertSame(
+            $expectedFiles,
+            PackageAutoload
+                ::fromComposerRootPackage($rootPackage, realpath(__DIR__ . '/..'))
+                ->files()
+        );
+    }
+
+    public function expectedFiles() : array
+    {
+        return [
+            'empty definition'                          => [
+                [],
+                [],
+            ],
+            'definition with non-existing classmap'     => [
+                [
+                    'classmap' => ['non-existing'],
+                ],
+                [],
+            ],
+            'definition with classmap pointing to file' => [
+                [
+                    'classmap' => ['Composer/PackageAutoloadTest.php'],
+                ],
+                [
+                    realpath(__FILE__),
+                ],
+            ],
+            'definition with directory classmap'        => [
+                [
+                    'classmap' => ['Composer', 'Psalm'],
+                ],
+                [],
+            ],
+        ];
+    }
+
+
+    /** @dataProvider expectedNamespaces */
+    public function testNamespacesFromAutoloadDefinition(
+        array $autoloadDefinition,
+        array $expectedNamespaces
+    ) : void {
+        self::assertSame(
+            $expectedNamespaces,
+            PackageAutoload
+                ::fromAutoloadDefinition($autoloadDefinition, realpath(__DIR__ . '/..'))
+                ->namespaces()
+        );
+    }
+
+
+    /** @dataProvider expectedNamespaces */
+    public function testNamespacesFromRootPackage(
+        array $autoloadDefinition,
+        array $expectedNamespaces
+    ) : void {
+        $rootPackage = $this->createMock(RootPackageInterface::class);
+
+        $rootPackage
+            ->method('getAutoload')
+            ->willReturn($autoloadDefinition);
+
+        self::assertSame(
+            $expectedNamespaces,
+            PackageAutoload
+                ::fromComposerRootPackage($rootPackage, realpath(__DIR__ . '/..'))
+                ->namespaces()
+        );
+    }
+
+    public function expectedNamespaces() : array
+    {
+        return [
+            'empty definition'                                    => [
+                [],
+                [],
+            ],
+            'definition with non-existing psr-4 single directory' => [
+                [
+                    'psr-4' => ['Non\\Existing\\' => 'foo'],
+                ],
+                ['Non\\Existing\\'],
+            ],
+            'definition with non-existing psr-4 array directory'  => [
+                [
+                    'psr-4' => ['Non\\Existing\\' => ['foo']],
+                ],
+                ['Non\\Existing\\'],
+            ],
+            'definition with existing psr-4 single directory'     => [
+                [
+                    'psr-4' => ['Non\\Existing\\' => 'Composer'],
+                ],
+                ['Non\\Existing\\'],
+            ],
+            'definition with multiple existing psr-4 directories' => [
+                [
+                    'psr-4' => [
+                        'Non\\Existing\\' => 'Composer',
+                        'Another\\Ns\\'   => 'Psalm',
+                    ],
+                ],
+                [
+                    'Non\\Existing\\',
+                    'Another\\Ns\\',
+                ],
+            ],
+            'definition with non-existing psr-0 single directory' => [
+                [
+                    'psr-0' => ['Non_Existing_' => 'foo'],
+                ],
+                ['Non_Existing_'],
+            ],
+            'definition with non-existing psr-0 array directory'  => [
+                [
+                    'psr-0' => ['Non_Existing_' => ['foo']],
+                ],
+                ['Non_Existing_'],
+            ],
+            'definition with existing psr-0 single directory'     => [
+                [
+                    'psr-0' => ['Non_Existing_' => 'Composer'],
+                ],
+                ['Non_Existing_'],
+            ],
+            'definition with multiple existing psr-0 directories' => [
+                [
+                    'psr-0' => [
+                        'Non_Existing_' => 'Composer',
+                        'Another_Ns_'   => 'Psalm',
+                    ],
+                ],
+                [
+                    'Non_Existing_',
+                    'Another_Ns_',
+                ],
+            ]
+        ];
+    }
+}

--- a/test/unit/Composer/PackageTest.php
+++ b/test/unit/Composer/PackageTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\YouAreUsingItWrong\Composer;
+
+use Composer\Package\RootPackageInterface;
+use PHPUnit\Framework\TestCase;
+use Roave\YouAreUsingItWrong\Composer\Package;
+use Roave\YouAreUsingItWrong\Composer\PackageAutoload;
+
+/**
+ * @covers \Roave\YouAreUsingItWrong\Composer\Package
+ *
+ * @uses \Roave\YouAreUsingItWrong\Composer\PackageAutoload
+ */
+final class PackageTest extends TestCase
+{
+    /** @dataProvider dependencyCombinationsThatRequireStrictChecks */
+    public function testRequiresStrictChecks(
+        bool $expected,
+        string ...$dependencies
+    ) : void {
+        self::assertSame(
+            $expected,
+            Package::fromPackageDefinition(
+                [
+                    'name'    => 'foo/bar',
+                    'require' => array_combine($dependencies, $dependencies),
+                ],
+                __DIR__
+            )
+                   ->requiresStrictChecks()
+        );
+    }
+
+    public function dependencyCombinationsThatRequireStrictChecks() : array
+    {
+        return [
+            [false, 'aaa/bbb'],
+            [true, 'roave/enforce-type-checks'],
+            [true, 'aaa/bbb', 'roave/enforce-type-checks'],
+            [false, 'roave/potato'],
+        ];
+    }
+
+    public function testName() : void
+    {
+        self::assertSame(
+            'foo/bar',
+            Package::fromPackageDefinition(
+                ['name' => 'foo/bar'],
+                __DIR__
+            )
+                   ->name()
+        );
+    }
+
+    public function testAutoload() : void
+    {
+        self::assertEquals(
+            PackageAutoload::fromAutoloadDefinition(
+                [
+                    'psr-0' => ['Foo_' => 'bar'],
+                ],
+                __DIR__
+            ),
+            Package::fromPackageDefinition(
+                [
+                    'name'     => 'foo/bar',
+                    'autoload' => [
+                        'psr-0' => ['Foo_' => 'bar'],
+                    ],
+                ],
+                __DIR__
+            )
+                   ->autoload()
+        );
+    }
+}

--- a/test/unit/Composer/PackageTest.php
+++ b/test/unit/Composer/PackageTest.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace RoaveTest\YouAreUsingItWrong\Composer;
 
-use Composer\Package\RootPackageInterface;
 use PHPUnit\Framework\TestCase;
 use Roave\YouAreUsingItWrong\Composer\Package;
 use Roave\YouAreUsingItWrong\Composer\PackageAutoload;
+use function array_combine;
 
 /**
- * @covers \Roave\YouAreUsingItWrong\Composer\Package
- *
  * @uses \Roave\YouAreUsingItWrong\Composer\PackageAutoload
+ *
+ * @covers \Roave\YouAreUsingItWrong\Composer\Package
  */
 final class PackageTest extends TestCase
 {
-    /** @dataProvider dependencyCombinationsThatRequireStrictChecks */
+    /**
+     * @dataProvider dependencyCombinationsThatRequireStrictChecks
+     */
     public function testRequiresStrictChecks(
         bool $expected,
         string ...$dependencies
@@ -34,6 +36,11 @@ final class PackageTest extends TestCase
         );
     }
 
+    /**
+     * @return array<int, bool|string>
+     *
+     * @psalm-return array<int, array{0: bool, 1: string, 2?: string}>
+     */
     public function dependencyCombinationsThatRequireStrictChecks() : array
     {
         return [

--- a/test/unit/Composer/PackageTest.php
+++ b/test/unit/Composer/PackageTest.php
@@ -45,8 +45,8 @@ final class PackageTest extends TestCase
     {
         return [
             [false, 'aaa/bbb'],
-            [true, 'roave/enforce-type-checks'],
-            [true, 'aaa/bbb', 'roave/enforce-type-checks'],
+            [true, 'roave/you-are-using-it-wrong'],
+            [true, 'aaa/bbb', 'roave/you-are-using-it-wrong'],
             [false, 'roave/potato'],
         ];
     }

--- a/test/unit/Composer/PackagesRequiringStrictChecksTest.php
+++ b/test/unit/Composer/PackagesRequiringStrictChecksTest.php
@@ -9,10 +9,10 @@ use PHPUnit\Framework\TestCase;
 use Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks;
 
 /**
- * @covers \Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks
- *
  * @uses \Roave\YouAreUsingItWrong\Composer\Package
  * @uses \Roave\YouAreUsingItWrong\Composer\PackageAutoload
+ *
+ * @covers \Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks
  */
 final class PackagesRequiringStrictChecksTest extends TestCase
 {
@@ -32,9 +32,7 @@ final class PackagesRequiringStrictChecksTest extends TestCase
                                 'Foo\\Baz\\' => ['bbb'],
                             ],
                         ],
-                        'require'  => [
-                            'roave/enforce-type-checks' => '1.2.3',
-                        ],
+                        'require'  => ['roave/enforce-type-checks' => '1.2.3'],
                     ],
                     [
                         'name'     => 'ignore/me',
@@ -43,9 +41,7 @@ final class PackagesRequiringStrictChecksTest extends TestCase
                                 'Ignore\\Me\\' => ['ccc'],
                             ],
                         ],
-                        'require'  => [
-                            'something/else' => '4.5.6',
-                        ],
+                        'require'  => ['something/else' => '4.5.6'],
                     ],
                     [
                         'name'     => 'baz/tab',
@@ -54,9 +50,7 @@ final class PackagesRequiringStrictChecksTest extends TestCase
                                 'Baz\\Tab\\' => ['ddd'],
                             ],
                         ],
-                        'require'  => [
-                            'roave/enforce-type-checks' => '4.5.6',
-                        ],
+                        'require'  => ['roave/enforce-type-checks' => '4.5.6'],
                     ],
                 ],
                 'packages-dev' => [
@@ -67,9 +61,7 @@ final class PackagesRequiringStrictChecksTest extends TestCase
                                 'Taz\\Tar\\' => ['eee'],
                             ],
                         ],
-                        'require'  => [
-                            'roave/enforce-type-checks' => '7.8.9',
-                        ],
+                        'require'  => ['roave/enforce-type-checks' => '7.8.9'],
                     ],
                 ],
             ]);

--- a/test/unit/Composer/PackagesRequiringStrictChecksTest.php
+++ b/test/unit/Composer/PackagesRequiringStrictChecksTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\YouAreUsingItWrong\Composer;
+
+use Composer\Package\Locker;
+use PHPUnit\Framework\TestCase;
+use Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks;
+
+/**
+ * @covers \Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks
+ *
+ * @uses \Roave\YouAreUsingItWrong\Composer\Package
+ * @uses \Roave\YouAreUsingItWrong\Composer\PackageAutoload
+ */
+final class PackagesRequiringStrictChecksTest extends TestCase
+{
+    public function testNamespacesAndPackagesToBeTypeChecked() : void
+    {
+        $locker = $this->createMock(Locker::class);
+
+        $locker
+            ->method('getLockData')
+            ->willReturn([
+                'packages'     => [
+                    [
+                        'name'     => 'foo/bar',
+                        'autoload' => [
+                            'psr-4' => [
+                                'Foo\\Bar\\' => ['aaa'],
+                                'Foo\\Baz\\' => ['bbb'],
+                            ],
+                        ],
+                        'require'  => [
+                            'roave/enforce-type-checks' => '1.2.3',
+                        ],
+                    ],
+                    [
+                        'name'     => 'ignore/me',
+                        'autoload' => [
+                            'psr-4' => [
+                                'Ignore\\Me\\' => ['ccc'],
+                            ],
+                        ],
+                        'require'  => [
+                            'something/else' => '4.5.6',
+                        ],
+                    ],
+                    [
+                        'name'     => 'baz/tab',
+                        'autoload' => [
+                            'psr-4' => [
+                                'Baz\\Tab\\' => ['ddd'],
+                            ],
+                        ],
+                        'require'  => [
+                            'roave/enforce-type-checks' => '4.5.6',
+                        ],
+                    ],
+                ],
+                'packages-dev' => [
+                    [
+                        'name'     => 'taz/tar',
+                        'autoload' => [
+                            'psr-4' => [
+                                'Taz\\Tar\\' => ['eee'],
+                            ],
+                        ],
+                        'require'  => [
+                            'roave/enforce-type-checks' => '7.8.9',
+                        ],
+                    ],
+                ],
+            ]);
+
+        $packages = PackagesRequiringStrictChecks::fromComposerLocker($locker, __DIR__);
+
+        self::assertSame(
+            [
+                'Foo\\Bar\\',
+                'Foo\\Baz\\',
+                'Baz\\Tab\\',
+                'Taz\\Tar\\',
+            ],
+            $packages->namespacesForWhichUsagesAreToBeTypeChecked()
+        );
+        self::assertSame(
+            [
+                'foo/bar',
+                'baz/tab',
+                'taz/tar',
+            ],
+            $packages->packagesForWhichUsagesAreToBeTypeChecked()
+        );
+    }
+
+    public function testCanBeBuiltFromEmptyLockData() : void
+    {
+        $locker = $this->createMock(Locker::class);
+
+        $locker
+            ->method('getLockData')
+            ->willReturn([
+                'packages' => [],
+            ]);
+
+        $packages = PackagesRequiringStrictChecks::fromComposerLocker($locker, __DIR__);
+
+        self::assertEmpty($packages->namespacesForWhichUsagesAreToBeTypeChecked());
+        self::assertEmpty($packages->packagesForWhichUsagesAreToBeTypeChecked());
+    }
+}

--- a/test/unit/Composer/PackagesRequiringStrictChecksTest.php
+++ b/test/unit/Composer/PackagesRequiringStrictChecksTest.php
@@ -32,7 +32,7 @@ final class PackagesRequiringStrictChecksTest extends TestCase
                                 'Foo\\Baz\\' => ['bbb'],
                             ],
                         ],
-                        'require'  => ['roave/enforce-type-checks' => '1.2.3'],
+                        'require'  => ['roave/you-are-using-it-wrong' => '1.2.3'],
                     ],
                     [
                         'name'     => 'ignore/me',
@@ -50,7 +50,7 @@ final class PackagesRequiringStrictChecksTest extends TestCase
                                 'Baz\\Tab\\' => ['ddd'],
                             ],
                         ],
-                        'require'  => ['roave/enforce-type-checks' => '4.5.6'],
+                        'require'  => ['roave/you-are-using-it-wrong' => '4.5.6'],
                     ],
                 ],
                 'packages-dev' => [
@@ -61,7 +61,7 @@ final class PackagesRequiringStrictChecksTest extends TestCase
                                 'Taz\\Tar\\' => ['eee'],
                             ],
                         ],
-                        'require'  => ['roave/enforce-type-checks' => '7.8.9'],
+                        'require'  => ['roave/you-are-using-it-wrong' => '7.8.9'],
                     ],
                 ],
             ]);

--- a/test/unit/Composer/ProjectTest.php
+++ b/test/unit/Composer/ProjectTest.php
@@ -12,11 +12,11 @@ use Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks;
 use Roave\YouAreUsingItWrong\Composer\Project;
 
 /**
- * @covers \Roave\YouAreUsingItWrong\Composer\Project
- *
  * @uses \Roave\YouAreUsingItWrong\Composer\Package
  * @uses \Roave\YouAreUsingItWrong\Composer\PackageAutoload
  * @uses \Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks
+ *
+ * @covers \Roave\YouAreUsingItWrong\Composer\Project
  */
 final class ProjectTest extends TestCase
 {
@@ -37,9 +37,7 @@ final class ProjectTest extends TestCase
                                 'Foo\\Baz\\' => ['bbb'],
                             ],
                         ],
-                        'require'  => [
-                            'roave/enforce-type-checks' => '1.2.3',
-                        ],
+                        'require'  => ['roave/enforce-type-checks' => '1.2.3'],
                     ],
                     [
                         'name'     => 'ignore/me',
@@ -48,9 +46,7 @@ final class ProjectTest extends TestCase
                                 'Ignore\\Me\\' => ['ccc'],
                             ],
                         ],
-                        'require'  => [
-                            'something/else' => '4.5.6',
-                        ],
+                        'require'  => ['something/else' => '4.5.6'],
                     ],
                     [
                         'name'     => 'baz/tab',
@@ -59,9 +55,7 @@ final class ProjectTest extends TestCase
                                 'Baz\\Tab\\' => ['ddd'],
                             ],
                         ],
-                        'require'  => [
-                            'roave/enforce-type-checks' => '4.5.6',
-                        ],
+                        'require'  => ['roave/enforce-type-checks' => '4.5.6'],
                     ],
                 ],
                 'packages-dev' => [
@@ -72,9 +66,7 @@ final class ProjectTest extends TestCase
                                 'Taz\\Tar\\' => ['eee'],
                             ],
                         ],
-                        'require'  => [
-                            'roave/enforce-type-checks' => '7.8.9',
-                        ],
+                        'require'  => ['roave/enforce-type-checks' => '7.8.9'],
                     ],
                 ],
             ]);
@@ -124,13 +116,9 @@ final class ProjectTest extends TestCase
                                 'Foo\\Baz\\' => ['bbb'],
                             ],
                         ],
-                        'require'  => [
-                            'roave/enforce-type-checks' => '1.2.3',
-                        ],
+                        'require'  => ['roave/enforce-type-checks' => '1.2.3'],
                     ],
-                    [
-                        'name' => 'roave/enforce-type-checks',
-                    ],
+                    ['name' => 'roave/enforce-type-checks'],
                 ],
             ]);
 
@@ -167,15 +155,11 @@ final class ProjectTest extends TestCase
                                 'Foo\\Baz\\' => ['bbb'],
                             ],
                         ],
-                        'require'  => [
-                            'roave/enforce-type-checks' => '1.2.3',
-                        ],
+                        'require'  => ['roave/enforce-type-checks' => '1.2.3'],
                     ],
                 ],
                 'packages-dev' => [
-                    [
-                        'name' => 'roave/enforce-type-checks',
-                    ],
+                    ['name' => 'roave/enforce-type-checks'],
                 ],
             ]);
 

--- a/test/unit/Composer/ProjectTest.php
+++ b/test/unit/Composer/ProjectTest.php
@@ -37,7 +37,7 @@ final class ProjectTest extends TestCase
                                 'Foo\\Baz\\' => ['bbb'],
                             ],
                         ],
-                        'require'  => ['roave/enforce-type-checks' => '1.2.3'],
+                        'require'  => ['roave/you-are-using-it-wrong' => '1.2.3'],
                     ],
                     [
                         'name'     => 'ignore/me',
@@ -55,7 +55,7 @@ final class ProjectTest extends TestCase
                                 'Baz\\Tab\\' => ['ddd'],
                             ],
                         ],
-                        'require'  => ['roave/enforce-type-checks' => '4.5.6'],
+                        'require'  => ['roave/you-are-using-it-wrong' => '4.5.6'],
                     ],
                 ],
                 'packages-dev' => [
@@ -66,7 +66,7 @@ final class ProjectTest extends TestCase
                                 'Taz\\Tar\\' => ['eee'],
                             ],
                         ],
-                        'require'  => ['roave/enforce-type-checks' => '7.8.9'],
+                        'require'  => ['roave/you-are-using-it-wrong' => '7.8.9'],
                     ],
                 ],
             ]);
@@ -116,9 +116,9 @@ final class ProjectTest extends TestCase
                                 'Foo\\Baz\\' => ['bbb'],
                             ],
                         ],
-                        'require'  => ['roave/enforce-type-checks' => '1.2.3'],
+                        'require'  => ['roave/you-are-using-it-wrong' => '1.2.3'],
                     ],
-                    ['name' => 'roave/enforce-type-checks'],
+                    ['name' => 'roave/you-are-using-it-wrong'],
                 ],
             ]);
 
@@ -155,11 +155,11 @@ final class ProjectTest extends TestCase
                                 'Foo\\Baz\\' => ['bbb'],
                             ],
                         ],
-                        'require'  => ['roave/enforce-type-checks' => '1.2.3'],
+                        'require'  => ['roave/you-are-using-it-wrong' => '1.2.3'],
                     ],
                 ],
                 'packages-dev' => [
-                    ['name' => 'roave/enforce-type-checks'],
+                    ['name' => 'roave/you-are-using-it-wrong'],
                 ],
             ]);
 

--- a/test/unit/Composer/ProjectTest.php
+++ b/test/unit/Composer/ProjectTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\YouAreUsingItWrong\Composer;
+
+use Composer\Package\Locker;
+use Composer\Package\RootPackageInterface;
+use PHPUnit\Framework\TestCase;
+use Roave\YouAreUsingItWrong\Composer\PackageAutoload;
+use Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks;
+use Roave\YouAreUsingItWrong\Composer\Project;
+
+/**
+ * @covers \Roave\YouAreUsingItWrong\Composer\Project
+ *
+ * @uses \Roave\YouAreUsingItWrong\Composer\Package
+ * @uses \Roave\YouAreUsingItWrong\Composer\PackageAutoload
+ * @uses \Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks
+ */
+final class ProjectTest extends TestCase
+{
+    public function testPackageWithoutLocalPluginInstallation() : void
+    {
+        $rootPackage = $this->createMock(RootPackageInterface::class);
+        $locker      = $this->createMock(Locker::class);
+
+        $locker
+            ->method('getLockData')
+            ->willReturn([
+                'packages'     => [
+                    [
+                        'name'     => 'foo/bar',
+                        'autoload' => [
+                            'psr-4' => [
+                                'Foo\\Bar\\' => ['aaa'],
+                                'Foo\\Baz\\' => ['bbb'],
+                            ],
+                        ],
+                        'require'  => [
+                            'roave/enforce-type-checks' => '1.2.3',
+                        ],
+                    ],
+                    [
+                        'name'     => 'ignore/me',
+                        'autoload' => [
+                            'psr-4' => [
+                                'Ignore\\Me\\' => ['ccc'],
+                            ],
+                        ],
+                        'require'  => [
+                            'something/else' => '4.5.6',
+                        ],
+                    ],
+                    [
+                        'name'     => 'baz/tab',
+                        'autoload' => [
+                            'psr-4' => [
+                                'Baz\\Tab\\' => ['ddd'],
+                            ],
+                        ],
+                        'require'  => [
+                            'roave/enforce-type-checks' => '4.5.6',
+                        ],
+                    ],
+                ],
+                'packages-dev' => [
+                    [
+                        'name'     => 'taz/tar',
+                        'autoload' => [
+                            'psr-4' => [
+                                'Taz\\Tar\\' => ['eee'],
+                            ],
+                        ],
+                        'require'  => [
+                            'roave/enforce-type-checks' => '7.8.9',
+                        ],
+                    ],
+                ],
+            ]);
+
+        $rootPackage
+            ->method('getAutoload')
+            ->willReturn([
+                'psr-0' => ['Foo_' => 'bar'],
+            ]);
+
+        $project = Project::fromComposerInstallationContext(
+            $rootPackage,
+            $locker,
+            __DIR__
+        );
+
+        self::assertEquals(
+            PackagesRequiringStrictChecks::fromComposerLocker($locker, __DIR__),
+            $project->packagesRequiringStrictTypeChecks()
+        );
+        self::assertEquals(
+            PackageAutoload::fromAutoloadDefinition(
+                [
+                    'psr-0' => ['Foo_' => 'bar'],
+                ],
+                __DIR__
+            ),
+            $project->rootPackageAutoload()
+        );
+        self::assertFalse($project->strictTypeChecksAreEnforcedByLocalInstallation());
+    }
+
+    public function testPackageWithLocalPluginInstallation() : void
+    {
+        $rootPackage = $this->createMock(RootPackageInterface::class);
+        $locker      = $this->createMock(Locker::class);
+
+        $locker
+            ->method('getLockData')
+            ->willReturn([
+                'packages' => [
+                    [
+                        'name'     => 'foo/bar',
+                        'autoload' => [
+                            'psr-4' => [
+                                'Foo\\Bar\\' => ['aaa'],
+                                'Foo\\Baz\\' => ['bbb'],
+                            ],
+                        ],
+                        'require'  => [
+                            'roave/enforce-type-checks' => '1.2.3',
+                        ],
+                    ],
+                    [
+                        'name' => 'roave/enforce-type-checks',
+                    ],
+                ],
+            ]);
+
+        $rootPackage
+            ->method('getAutoload')
+            ->willReturn([
+                'psr-0' => ['Foo_' => 'bar'],
+            ]);
+
+        self::assertTrue(
+            Project::fromComposerInstallationContext(
+                $rootPackage,
+                $locker,
+                __DIR__
+            )
+                   ->strictTypeChecksAreEnforcedByLocalInstallation()
+        );
+    }
+
+    public function testPackageWithLocalPluginDevInstallation() : void
+    {
+        $rootPackage = $this->createMock(RootPackageInterface::class);
+        $locker      = $this->createMock(Locker::class);
+
+        $locker
+            ->method('getLockData')
+            ->willReturn([
+                'packages'     => [
+                    [
+                        'name'     => 'foo/bar',
+                        'autoload' => [
+                            'psr-4' => [
+                                'Foo\\Bar\\' => ['aaa'],
+                                'Foo\\Baz\\' => ['bbb'],
+                            ],
+                        ],
+                        'require'  => [
+                            'roave/enforce-type-checks' => '1.2.3',
+                        ],
+                    ],
+                ],
+                'packages-dev' => [
+                    [
+                        'name' => 'roave/enforce-type-checks',
+                    ],
+                ],
+            ]);
+
+        $rootPackage
+            ->method('getAutoload')
+            ->willReturn([
+                'psr-0' => ['Foo_' => 'bar'],
+            ]);
+
+        self::assertTrue(
+            Project::fromComposerInstallationContext(
+                $rootPackage,
+                $locker,
+                __DIR__
+            )
+                   ->strictTypeChecksAreEnforcedByLocalInstallation()
+        );
+    }
+}

--- a/test/unit/Composer/ProjectTest.php
+++ b/test/unit/Composer/ProjectTest.php
@@ -12,9 +12,9 @@ use Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks;
 use Roave\YouAreUsingItWrong\Composer\Project;
 
 /**
- * @uses \Roave\YouAreUsingItWrong\Composer\Package
- * @uses \Roave\YouAreUsingItWrong\Composer\PackageAutoload
- * @uses \Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks
+ * @uses   \Roave\YouAreUsingItWrong\Composer\Package
+ * @uses   \Roave\YouAreUsingItWrong\Composer\PackageAutoload
+ * @uses   \Roave\YouAreUsingItWrong\Composer\PackagesRequiringStrictChecks
  *
  * @covers \Roave\YouAreUsingItWrong\Composer\Project
  */
@@ -97,6 +97,7 @@ final class ProjectTest extends TestCase
             $project->rootPackageAutoload()
         );
         self::assertFalse($project->strictTypeChecksAreEnforcedByLocalInstallation());
+        self::assertFalse($project->alreadyHasOwnPsalmConfiguration());
     }
 
     public function testPackageWithLocalPluginInstallation() : void
@@ -176,6 +177,29 @@ final class ProjectTest extends TestCase
                 __DIR__
             )
                    ->strictTypeChecksAreEnforcedByLocalInstallation()
+        );
+    }
+
+    public function testProjectWhichAlreadyHasAPsalmConfiguration() : void
+    {
+        $rootPackage = $this->createMock(RootPackageInterface::class);
+        $locker      = $this->createMock(Locker::class);
+
+        $locker
+            ->method('getLockData')
+            ->willReturn(['packages' => []]);
+
+        $rootPackage
+            ->method('getAutoload')
+            ->willReturn([]);
+
+        self::assertTrue(
+            Project::fromComposerInstallationContext(
+                $rootPackage,
+                $locker,
+                __DIR__ . '/../../..'
+            )
+                   ->alreadyHasOwnPsalmConfiguration()
         );
     }
 }

--- a/test/unit/Psalm/ConfigurationTest.php
+++ b/test/unit/Psalm/ConfigurationTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\YouAreUsingItWrong\Psalm;
+
+use PHPUnit\Framework\TestCase;
+use Psalm\Config\ProjectFileFilter;
+use Psalm\Issue\ArgumentIssue;
+use Psalm\Issue\ClassIssue;
+use Psalm\Issue\CodeIssue;
+use Psalm\Issue\FunctionIssue;
+use Psalm\Issue\MethodIssue;
+use Psalm\Issue\PropertyIssue;
+use Roave\YouAreUsingItWrong\Psalm\Configuration;
+
+/** @covers \Roave\YouAreUsingItWrong\Psalm\Configuration */
+final class ConfigurationTest extends TestCase
+{
+    public function testConfigurationDefaults() : void
+    {
+        $reflectionFiles            = new \ReflectionProperty(Configuration::class, 'project_files');
+        $reflectionPhpstormGenerics = new \ReflectionProperty(Configuration::class, 'allow_phpstorm_generics');
+        $reflectionUseDocblockTypes = new \ReflectionProperty(Configuration::class, 'use_docblock_types');
+        $reflectionTotallyTyped     = new \ReflectionProperty(Configuration::class, 'totally_typed');
+
+        $reflectionFiles->setAccessible(true);
+        $reflectionPhpstormGenerics->setAccessible(true);
+        $reflectionUseDocblockTypes->setAccessible(true);
+        $reflectionTotallyTyped->setAccessible(true);
+
+        $projectFiles  = $this->createMock(ProjectFileFilter::class);
+        $configuration = Configuration::forStrictlyCheckedNamespacesAndProjectFiles($projectFiles);
+
+        self::assertSame($projectFiles, $reflectionFiles->getValue($configuration));
+        self::assertTrue($reflectionPhpstormGenerics->getValue($configuration));
+        self::assertTrue($reflectionUseDocblockTypes->getValue($configuration));
+        self::assertTrue($reflectionTotallyTyped->getValue($configuration));
+    }
+
+    /** @dataProvider expectedReportingLevels */
+    public function testCheckedNamespaces(
+        CodeIssue $issue,
+        string $expectedReportingLevel,
+        string ...$checkedNamespaces
+    ) : void {
+        $projectFiles = $this->createMock(ProjectFileFilter::class);
+
+        self::assertSame(
+            $expectedReportingLevel,
+            Configuration
+                ::forStrictlyCheckedNamespacesAndProjectFiles($projectFiles, ...$checkedNamespaces)
+                ->getReportingLevelForIssue($issue)
+        );
+    }
+
+    public function expectedReportingLevels() : array
+    {
+        $classIssue    = $this->createMock(ClassIssue::class);
+        $propertyIssue = $this->createMock(PropertyIssue::class);
+        $methodIssue   = $this->createMock(MethodIssue::class);
+        $functionIssue = $this->createMock(FunctionIssue::class);
+        $argumentIssue = $this->createMock(ArgumentIssue::class);
+
+        $classIssue->fq_classlike_name = 'Foo\\Bar\\Baz';
+        $propertyIssue->property_id    = 'Foo\\Bar\\Baz$property';
+        $methodIssue->method_id        = 'Foo\\Bar\\Baz::method';
+        $functionIssue->function_id    = 'Foo\\Bar\\Baz\\function_name';
+        $argumentIssue->function_id    = 'Foo\\Bar\\Baz\\function_name';
+
+        return [
+            'no namespaces, class issue'                           => [
+                $classIssue,
+                Configuration::REPORT_SUPPRESS,
+            ],
+            'non-matching namespaces, class issue'                 => [
+                $classIssue,
+                Configuration::REPORT_SUPPRESS,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'Bar\\',
+            ],
+            'matching namespaces, class issue'                     => [
+                $classIssue,
+                Configuration::REPORT_ERROR,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'Foo\\Bar\\',
+            ],
+            'case-insensitive matching namespaces, class issue'    => [
+                $classIssue,
+                Configuration::REPORT_ERROR,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'foo\\',
+            ],
+            'no namespaces, property issue'                        => [
+                $propertyIssue,
+                Configuration::REPORT_SUPPRESS,
+            ],
+            'non-matching namespaces, property issue'              => [
+                $propertyIssue,
+                Configuration::REPORT_SUPPRESS,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'Bar\\',
+            ],
+            'matching namespaces, property issue'                  => [
+                $propertyIssue,
+                Configuration::REPORT_ERROR,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'Foo\\Bar\\',
+            ],
+            'case-insensitive matching namespaces, property issue' => [
+                $propertyIssue,
+                Configuration::REPORT_ERROR,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'foo\\',
+            ],
+            'no namespaces, method issue'                          => [
+                $methodIssue,
+                Configuration::REPORT_SUPPRESS,
+            ],
+            'non-matching namespaces, method issue'                => [
+                $methodIssue,
+                Configuration::REPORT_SUPPRESS,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'Bar\\',
+            ],
+            'matching namespaces, method issue'                    => [
+                $methodIssue,
+                Configuration::REPORT_ERROR,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'Foo\\Bar\\',
+            ],
+            'case-insensitive matching namespaces, method issue'   => [
+                $methodIssue,
+                Configuration::REPORT_ERROR,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'foo\\',
+            ],
+            'no namespaces, function issue'                        => [
+                $functionIssue,
+                Configuration::REPORT_SUPPRESS,
+            ],
+            'non-matching namespaces, function issue'              => [
+                $functionIssue,
+                Configuration::REPORT_SUPPRESS,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'Bar\\',
+            ],
+            'matching namespaces, function issue'                  => [
+                $functionIssue,
+                Configuration::REPORT_ERROR,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'Foo\\Bar\\',
+            ],
+            'case-insensitive matching namespaces, function issue' => [
+                $functionIssue,
+                Configuration::REPORT_ERROR,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'foo\\',
+            ],
+            'no namespaces, argument issue'                        => [
+                $argumentIssue,
+                Configuration::REPORT_SUPPRESS,
+            ],
+            'non-matching namespaces, argument issue'              => [
+                $argumentIssue,
+                Configuration::REPORT_SUPPRESS,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'Bar\\',
+            ],
+            'matching namespaces, argument issue'                  => [
+                $argumentIssue,
+                Configuration::REPORT_ERROR,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'Foo\\Bar\\',
+            ],
+            'case-insensitive matching namespaces, argument issue' => [
+                $argumentIssue,
+                Configuration::REPORT_ERROR,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'foo\\',
+            ],
+        ];
+    }
+}

--- a/test/unit/Psalm/ConfigurationTest.php
+++ b/test/unit/Psalm/ConfigurationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace RoaveTest\YouAreUsingItWrong\Psalm;
 
 use PHPUnit\Framework\TestCase;
+use Psalm\Config;
 use Psalm\Config\ProjectFileFilter;
 use Psalm\Issue\ArgumentIssue;
 use Psalm\Issue\ClassIssue;
@@ -24,11 +25,13 @@ final class ConfigurationTest extends TestCase
         $reflectionPhpstormGenerics = new ReflectionProperty(Configuration::class, 'allow_phpstorm_generics');
         $reflectionUseDocblockTypes = new ReflectionProperty(Configuration::class, 'use_docblock_types');
         $reflectionTotallyTyped     = new ReflectionProperty(Configuration::class, 'totally_typed');
+        $reflectionInstance         = new ReflectionProperty(Config::class, 'instance');
 
         $reflectionFiles->setAccessible(true);
         $reflectionPhpstormGenerics->setAccessible(true);
         $reflectionUseDocblockTypes->setAccessible(true);
         $reflectionTotallyTyped->setAccessible(true);
+        $reflectionInstance->setAccessible(true);
 
         $projectFiles  = $this->createMock(ProjectFileFilter::class);
         $configuration = Configuration::forStrictlyCheckedNamespacesAndProjectFiles($projectFiles);
@@ -37,6 +40,7 @@ final class ConfigurationTest extends TestCase
         self::assertTrue($reflectionPhpstormGenerics->getValue($configuration));
         self::assertTrue($reflectionUseDocblockTypes->getValue($configuration));
         self::assertTrue($reflectionTotallyTyped->getValue($configuration));
+        self::assertSame($configuration, $reflectionInstance->getValue($configuration));
     }
 
     /**

--- a/test/unit/Psalm/ConfigurationTest.php
+++ b/test/unit/Psalm/ConfigurationTest.php
@@ -12,6 +12,7 @@ use Psalm\Issue\CodeIssue;
 use Psalm\Issue\FunctionIssue;
 use Psalm\Issue\MethodIssue;
 use Psalm\Issue\PropertyIssue;
+use ReflectionProperty;
 use Roave\YouAreUsingItWrong\Psalm\Configuration;
 
 /** @covers \Roave\YouAreUsingItWrong\Psalm\Configuration */
@@ -19,10 +20,10 @@ final class ConfigurationTest extends TestCase
 {
     public function testConfigurationDefaults() : void
     {
-        $reflectionFiles            = new \ReflectionProperty(Configuration::class, 'project_files');
-        $reflectionPhpstormGenerics = new \ReflectionProperty(Configuration::class, 'allow_phpstorm_generics');
-        $reflectionUseDocblockTypes = new \ReflectionProperty(Configuration::class, 'use_docblock_types');
-        $reflectionTotallyTyped     = new \ReflectionProperty(Configuration::class, 'totally_typed');
+        $reflectionFiles            = new ReflectionProperty(Configuration::class, 'project_files');
+        $reflectionPhpstormGenerics = new ReflectionProperty(Configuration::class, 'allow_phpstorm_generics');
+        $reflectionUseDocblockTypes = new ReflectionProperty(Configuration::class, 'use_docblock_types');
+        $reflectionTotallyTyped     = new ReflectionProperty(Configuration::class, 'totally_typed');
 
         $reflectionFiles->setAccessible(true);
         $reflectionPhpstormGenerics->setAccessible(true);
@@ -38,7 +39,9 @@ final class ConfigurationTest extends TestCase
         self::assertTrue($reflectionTotallyTyped->getValue($configuration));
     }
 
-    /** @dataProvider expectedReportingLevels */
+    /**
+     * @dataProvider expectedReportingLevels
+     */
     public function testCheckedNamespaces(
         CodeIssue $issue,
         string $expectedReportingLevel,
@@ -48,12 +51,16 @@ final class ConfigurationTest extends TestCase
 
         self::assertSame(
             $expectedReportingLevel,
-            Configuration
-                ::forStrictlyCheckedNamespacesAndProjectFiles($projectFiles, ...$checkedNamespaces)
+            Configuration::forStrictlyCheckedNamespacesAndProjectFiles($projectFiles, ...$checkedNamespaces)
                 ->getReportingLevelForIssue($issue)
         );
     }
 
+    /**
+     * @return array<string, array<int, CodeIssue|string>>
+     *
+     * @psalm-return array<string, array{0: CodeIssue, 1: string}>
+     */
     public function expectedReportingLevels() : array
     {
         $classIssue    = $this->createMock(ClassIssue::class);

--- a/test/unit/Psalm/ConfigurationTest.php
+++ b/test/unit/Psalm/ConfigurationTest.php
@@ -56,7 +56,7 @@ final class ConfigurationTest extends TestCase
         self::assertSame(
             $expectedReportingLevel,
             Configuration::forStrictlyCheckedNamespacesAndProjectFiles($projectFiles, ...$checkedNamespaces)
-                ->getReportingLevelForIssue($issue)
+                         ->getReportingLevelForIssue($issue)
         );
     }
 
@@ -67,12 +67,13 @@ final class ConfigurationTest extends TestCase
      */
     public function expectedReportingLevels() : array
     {
-        $classIssue    = $this->createMock(ClassIssue::class);
-        $propertyIssue = $this->createMock(PropertyIssue::class);
-        $methodIssue   = $this->createMock(MethodIssue::class);
-        $functionIssue = $this->createMock(FunctionIssue::class);
-        $argumentIssue = $this->createMock(ArgumentIssue::class);
-        $genericIssue  = $this->createMock(CodeIssue::class);
+        $classIssue             = $this->createMock(ClassIssue::class);
+        $propertyIssue          = $this->createMock(PropertyIssue::class);
+        $methodIssue            = $this->createMock(MethodIssue::class);
+        $functionIssue          = $this->createMock(FunctionIssue::class);
+        $argumentIssue          = $this->createMock(ArgumentIssue::class);
+        $anonymousArgumentIssue = $this->createMock(ArgumentIssue::class);
+        $genericIssue           = $this->createMock(CodeIssue::class);
 
         $classIssue->fq_classlike_name = 'Foo\\Bar\\Baz';
         $propertyIssue->property_id    = 'Foo\\Bar\\Baz$property';
@@ -206,7 +207,14 @@ final class ConfigurationTest extends TestCase
                 'AAA\\BBB\\',
                 'foo\\',
             ],
-            'generic issue type' => [
+            'anonymous argument issue'                             => [
+                $anonymousArgumentIssue,
+                Configuration::REPORT_SUPPRESS,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'foo\\',
+            ],
+            'generic issue type'                                   => [
                 $genericIssue,
                 Configuration::REPORT_SUPPRESS,
                 'AAA\\BBB',

--- a/test/unit/Psalm/ConfigurationTest.php
+++ b/test/unit/Psalm/ConfigurationTest.php
@@ -72,6 +72,7 @@ final class ConfigurationTest extends TestCase
         $methodIssue   = $this->createMock(MethodIssue::class);
         $functionIssue = $this->createMock(FunctionIssue::class);
         $argumentIssue = $this->createMock(ArgumentIssue::class);
+        $genericIssue  = $this->createMock(CodeIssue::class);
 
         $classIssue->fq_classlike_name = 'Foo\\Bar\\Baz';
         $propertyIssue->property_id    = 'Foo\\Bar\\Baz$property';
@@ -201,6 +202,13 @@ final class ConfigurationTest extends TestCase
             'case-insensitive matching namespaces, argument issue' => [
                 $argumentIssue,
                 Configuration::REPORT_ERROR,
+                'AAA\\BBB',
+                'AAA\\BBB\\',
+                'foo\\',
+            ],
+            'generic issue type' => [
+                $genericIssue,
+                Configuration::REPORT_SUPPRESS,
                 'AAA\\BBB',
                 'AAA\\BBB\\',
                 'foo\\',

--- a/test/unit/Psalm/ProjectFilesToBeTypeCheckedTest.php
+++ b/test/unit/Psalm/ProjectFilesToBeTypeCheckedTest.php
@@ -10,7 +10,11 @@ use Roave\YouAreUsingItWrong\Composer\PackageAutoload;
 use Roave\YouAreUsingItWrong\Psalm\ProjectFilesToBeTypeChecked;
 use function realpath;
 
-/** @covers \Roave\YouAreUsingItWrong\Psalm\ProjectFilesToBeTypeChecked */
+/**
+ * @covers \Roave\YouAreUsingItWrong\Psalm\ProjectFilesToBeTypeChecked
+ *
+ * @uses \Roave\YouAreUsingItWrong\Composer\PackageAutoload
+ */
 final class ProjectFilesToBeTypeCheckedTest extends TestCase
 {
     public function testFilesToBeChecked() : void

--- a/test/unit/Psalm/ProjectFilesToBeTypeCheckedTest.php
+++ b/test/unit/Psalm/ProjectFilesToBeTypeCheckedTest.php
@@ -5,16 +5,10 @@ declare(strict_types=1);
 namespace RoaveTest\YouAreUsingItWrong\Psalm;
 
 use PHPUnit\Framework\TestCase;
-use Psalm\Config\ProjectFileFilter;
-use Psalm\Issue\ArgumentIssue;
-use Psalm\Issue\ClassIssue;
-use Psalm\Issue\CodeIssue;
-use Psalm\Issue\FunctionIssue;
-use Psalm\Issue\MethodIssue;
-use Psalm\Issue\PropertyIssue;
+use ReflectionProperty;
 use Roave\YouAreUsingItWrong\Composer\PackageAutoload;
-use Roave\YouAreUsingItWrong\Psalm\Configuration;
 use Roave\YouAreUsingItWrong\Psalm\ProjectFilesToBeTypeChecked;
+use function realpath;
 
 /** @covers \Roave\YouAreUsingItWrong\Psalm\ProjectFilesToBeTypeChecked */
 final class ProjectFilesToBeTypeCheckedTest extends TestCase
@@ -24,14 +18,14 @@ final class ProjectFilesToBeTypeCheckedTest extends TestCase
         $files = ProjectFilesToBeTypeChecked::fromAutoloadDefinitions(
             PackageAutoload::fromAutoloadDefinition(
                 [
-                    'psr-0'    => ['Composer'],
+                    'psr-0'    => ['Foo_' => 'Composer'],
                     'classmap' => ['Psalm/ProjectFilesToBeTypeCheckedTest.php'],
                 ],
                 __DIR__ . '/..'
             )
         );
 
-        $reflectionInclusive = new \ReflectionProperty(ProjectFilesToBeTypeChecked::class, 'inclusive');
+        $reflectionInclusive = new ReflectionProperty(ProjectFilesToBeTypeChecked::class, 'inclusive');
 
         $reflectionInclusive->setAccessible(true);
 

--- a/test/unit/Psalm/ProjectFilesToBeTypeCheckedTest.php
+++ b/test/unit/Psalm/ProjectFilesToBeTypeCheckedTest.php
@@ -11,9 +11,9 @@ use Roave\YouAreUsingItWrong\Psalm\ProjectFilesToBeTypeChecked;
 use function realpath;
 
 /**
- * @covers \Roave\YouAreUsingItWrong\Psalm\ProjectFilesToBeTypeChecked
- *
  * @uses \Roave\YouAreUsingItWrong\Composer\PackageAutoload
+ *
+ * @covers \Roave\YouAreUsingItWrong\Psalm\ProjectFilesToBeTypeChecked
  */
 final class ProjectFilesToBeTypeCheckedTest extends TestCase
 {

--- a/test/unit/Psalm/ProjectFilesToBeTypeCheckedTest.php
+++ b/test/unit/Psalm/ProjectFilesToBeTypeCheckedTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\YouAreUsingItWrong\Psalm;
+
+use PHPUnit\Framework\TestCase;
+use Psalm\Config\ProjectFileFilter;
+use Psalm\Issue\ArgumentIssue;
+use Psalm\Issue\ClassIssue;
+use Psalm\Issue\CodeIssue;
+use Psalm\Issue\FunctionIssue;
+use Psalm\Issue\MethodIssue;
+use Psalm\Issue\PropertyIssue;
+use Roave\YouAreUsingItWrong\Composer\PackageAutoload;
+use Roave\YouAreUsingItWrong\Psalm\Configuration;
+use Roave\YouAreUsingItWrong\Psalm\ProjectFilesToBeTypeChecked;
+
+/** @covers \Roave\YouAreUsingItWrong\Psalm\ProjectFilesToBeTypeChecked */
+final class ProjectFilesToBeTypeCheckedTest extends TestCase
+{
+    public function testFilesToBeChecked() : void
+    {
+        $files = ProjectFilesToBeTypeChecked::fromAutoloadDefinitions(
+            PackageAutoload::fromAutoloadDefinition(
+                [
+                    'psr-0'    => ['Composer'],
+                    'classmap' => ['Psalm/ProjectFilesToBeTypeCheckedTest.php'],
+                ],
+                __DIR__ . '/..'
+            )
+        );
+
+        $reflectionInclusive = new \ReflectionProperty(ProjectFilesToBeTypeChecked::class, 'inclusive');
+
+        $reflectionInclusive->setAccessible(true);
+
+        self::assertSame([realpath(__DIR__ . '/../Composer') . '/'], $files->getDirectories());
+        self::assertSame([realpath(__FILE__)], $files->getFiles());
+        self::assertTrue($reflectionInclusive->getValue($files));
+    }
+}

--- a/test/unit/TestHook.php
+++ b/test/unit/TestHook.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\YouAreUsingItWrong;
+
+use PHPUnit\Framework\TestCase;
+use Roave\YouAreUsingItWrong\Hook;
+
+/** @covers \Roave\YouAreUsingItWrong\Hook */
+final class TestHook extends TestCase
+{
+    public function testSubscribedEvents() : void
+    {
+        $subscribers = Hook::getSubscribedEvents();
+
+        self::assertSame(['post-install-cmd', 'post-update-cmd'], array_keys($subscribers));
+
+        foreach ($subscribers as $subscriber) {
+            self::assertIsCallable([Hook::class, $subscriber]);
+        }
+    }
+}

--- a/test/unit/TestHook.php
+++ b/test/unit/TestHook.php
@@ -6,6 +6,7 @@ namespace RoaveTest\YouAreUsingItWrong;
 
 use PHPUnit\Framework\TestCase;
 use Roave\YouAreUsingItWrong\Hook;
+use function array_keys;
 
 /** @covers \Roave\YouAreUsingItWrong\Hook */
 final class TestHook extends TestCase


### PR DESCRIPTION
Feature-wise, this patch:

 1. enforces type-checks in downstream packages (all the way down, even for indirect dependants)
 2. skips checks if `roave/you-are-using-it-wrong` is installed as global dependency, and not as local dependency
 3. skips checks if a `psalm.xml` is detected in the installation target project
 4. limits type checks to usages of namespaces that are "owned" by packages that explicitly `"require": "roave/you-are-using-it-wrong"`