### PR TITLE
Fix: Remove sudo configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 git:
   depth: false
 


### PR DESCRIPTION
This PR

* [x] removes outdated `sudo` configuration from `.travis.yml`

💁‍♂️ For reference, see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration.