### PR TITLE
Detect `psalm.xml.dist` file as a valid Psalm configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ $ echo $?
 ## Workarounds
 
 This package is designed to be quite invasive from a type-check perspective,
-but it will bail out of any checks if a [`psalm.xml`](https://psalm.dev/docs/configuration/)
+but it will bail out of any checks if a [`psalm configuration`](https://psalm.dev/docs/configuration/)
 is detected in the root of the installation/project.
 If that is the case, the tool assumes that the author of the project is already
 responsible for ensuring type-safety within their own domain, and therefore

--- a/src/Composer/Project.php
+++ b/src/Composer/Project.php
@@ -77,6 +77,6 @@ final class Project
 
     public function alreadyHasOwnPsalmConfiguration() : bool
     {
-        return file_exists($this->projectDirectory . '/psalm.xml');
+        return file_exists($this->projectDirectory . '/psalm.xml') || file_exists($this->projectDirectory . '/psalm.xml.dist');
     }
 }

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -60,7 +60,7 @@ final class Hook implements PluginInterface, EventSubscriberInterface
         }
 
         if ($project->alreadyHasOwnPsalmConfiguration()) {
-            $io->write('<info>' . self::THIS_PACKAGE_NAME . ':</info> psalm.xml detected - assuming static analysis will run later; not running psalm now');
+            $io->write('<info>' . self::THIS_PACKAGE_NAME . ':</info> psalm configuration detected - assuming static analysis will run later; not running psalm now');
 
             return;
         }

--- a/test/repositories/repository-with-dist-config/composer.json
+++ b/test/repositories/repository-with-dist-config/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "test/repository-with-dist-config"
+}

--- a/test/repositories/repository-with-dist-config/psalm.xml.dist
+++ b/test/repositories/repository-with-dist-config/psalm.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<psalm
+    xmlns="https://getpsalm.org/schema/config"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    name="Psalm dist configuration"
+>
+    <projectFiles>
+        <directory name="src"/>
+    </projectFiles>
+</psalm>

--- a/test/unit/Composer/ProjectTest.php
+++ b/test/unit/Composer/ProjectTest.php
@@ -180,7 +180,10 @@ final class ProjectTest extends TestCase
         );
     }
 
-    public function testProjectWhichAlreadyHasAPsalmConfiguration() : void
+    /**
+     * @dataProvider repositoryWithPsalmConfigurationProvider
+     */
+    public function testProjectWhichAlreadyHasAPsalmConfiguration(string $repositoryRoot) : void
     {
         $rootPackage = $this->createMock(RootPackageInterface::class);
         $locker      = $this->createMock(Locker::class);
@@ -197,9 +200,20 @@ final class ProjectTest extends TestCase
             Project::fromComposerInstallationContext(
                 $rootPackage,
                 $locker,
-                __DIR__ . '/../../..'
+                $repositoryRoot
             )
                    ->alreadyHasOwnPsalmConfiguration()
         );
+    }
+
+    /**
+     * @return array<string[]>
+     */
+    public function repositoryWithPsalmConfigurationProvider() : array
+    {
+        return [
+            [__DIR__ . '/../../..'],
+            [__DIR__ . '/../../repositories/repository-with-dist-config/'],
+        ];
     }
 }


### PR DESCRIPTION
Psalm also looks for [`psalm.xml.dist` file by default](https://github.com/vimeo/psalm/blob/a1eb191f57cd6ac1963ce7818d010f981564bb74/src/Psalm/Config.php) and the [Psalm repo itself uses a psalm.xml.dist file](a1eb191f57cd6ac1963ce7818d010f981564bb74).

This tool should probably try to detect them as well.