### PR TITLE
Removed `Psalm\Config#$totally_typed = 1` assignment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-json":                  "*",
         "composer-plugin-api":       "^1.0.0",
         "ocramius/package-versions": "^1.5.1",
-        "vimeo/psalm":               "^3.8.3"
+        "vimeo/psalm":               "^3.9.3"
     },
     "require-dev": {
         "composer/composer":        "^1.9.0",

--- a/src/Psalm/Configuration.php
+++ b/src/Psalm/Configuration.php
@@ -27,7 +27,6 @@ final class Configuration extends PsalmConfig
         $this->project_files           = $files;
         $this->allow_phpstorm_generics = true;
         $this->use_docblock_types      = true;
-        $this->totally_typed           = true;
         $this->checkedNamespaces       = $checkedNamespaces;
     }
 

--- a/test/unit/Psalm/ConfigurationTest.php
+++ b/test/unit/Psalm/ConfigurationTest.php
@@ -24,13 +24,11 @@ final class ConfigurationTest extends TestCase
         $reflectionFiles            = new ReflectionProperty(Configuration::class, 'project_files');
         $reflectionPhpstormGenerics = new ReflectionProperty(Configuration::class, 'allow_phpstorm_generics');
         $reflectionUseDocblockTypes = new ReflectionProperty(Configuration::class, 'use_docblock_types');
-        $reflectionTotallyTyped     = new ReflectionProperty(Configuration::class, 'totally_typed');
         $reflectionInstance         = new ReflectionProperty(Config::class, 'instance');
 
         $reflectionFiles->setAccessible(true);
         $reflectionPhpstormGenerics->setAccessible(true);
         $reflectionUseDocblockTypes->setAccessible(true);
-        $reflectionTotallyTyped->setAccessible(true);
         $reflectionInstance->setAccessible(true);
 
         $projectFiles  = $this->createMock(ProjectFileFilter::class);
@@ -39,7 +37,6 @@ final class ConfigurationTest extends TestCase
         self::assertSame($projectFiles, $reflectionFiles->getValue($configuration));
         self::assertTrue($reflectionPhpstormGenerics->getValue($configuration));
         self::assertTrue($reflectionUseDocblockTypes->getValue($configuration));
-        self::assertTrue($reflectionTotallyTyped->getValue($configuration));
         self::assertSame($configuration, $reflectionInstance->getValue($configuration));
     }
 


### PR DESCRIPTION
This property was removed in psalm 3.9.x, and the config is
now defaulting to the strictest level (1).

Ref: https://github.com/vimeo/psalm/issues/2899