### PR TITLE
Pipeline fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ before_script:
   - composer update --prefer-dist $DEPENDENCIES
 
 script:
-  - vendor/bin/phpunit --coverage-text --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml
-  - vendor/bin/psalm
   - vendor/bin/phpcs
+  - vendor/bin/psalm
+  - vendor/bin/phpunit --coverage-text --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml
   - vendor/bin/infection --min-msi=84 --min-covered-msi=100 --coverage=coverage --log-verbosity=none -s
   - cd example && ./run-example.sh

--- a/test/e2e/SimulatedInstallationTest.php
+++ b/test/e2e/SimulatedInstallationTest.php
@@ -14,10 +14,7 @@ final class SimulatedInstallationTest extends TestCase
 
     protected function tearDown() : void
     {
-//        if ($this->repository !== null) {
-//            (new Process(['rm', '-r', $this->repository]))
-//                ->mustRun();
-//        }
+        (new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], __DIR__ . '/../..'))->mustRun();
 
         parent::tearDown();
     }


### PR DESCRIPTION
when phpunit runs e2e `SimulatedInstallationTest` every test method runs this bit:
```php
new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], $this->repository)
```
where `__DIR__ . '/../../vendor/bin/composer'` resolves to composer installed in root directory e.g.:
```bash

string(84) "..../you-are-using-it-wrong/test/e2e/../../vendor/bin/composer"
```
and `$this->repository` equals to tmp installation directory, in my case :
```bash
string(29) "/tmp/test-installation-w1eCQP"
```
It seems that running `composer install` one more time for the root directory upon `tearDown` step  fixes the issue :thinking:   
I wonder how it worked before and what changed, probably should bisect repo in order to find out

