### PR TITLE
Require PHP 8 to make builds (especially `--prefer-lowest` and latest tests) stable again

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -15,7 +15,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "7.4"
+          - "8.0"
         operating-system:
           - "ubuntu-latest"
 

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -15,7 +15,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "7.4"
+          - "8.0"
         operating-system:
           - "ubuntu-latest"
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,7 +17,6 @@ jobs:
           - "highest"
           - "locked"
         php-version:
-          - "7.4"
           - "8.0"
         operating-system:
           - "ubuntu-latest"
@@ -47,15 +46,15 @@ jobs:
 
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}
-        run: "composer update --prefer-lowest --no-interaction --no-progress --ignore-platform-req=php"
+        run: "composer update --prefer-lowest --no-interaction --no-progress"
 
       - name: "Install highest dependencies"
         if: ${{ matrix.dependencies == 'highest' }}
-        run: "composer update --no-interaction --no-progress --ignore-platform-req=php"
+        run: "composer update --no-interaction --no-progress"
 
       - name: "Install locked dependencies"
         if: ${{ matrix.dependencies == 'locked' }}
-        run: "composer install --no-interaction --no-progress --ignore-platform-req=php"
+        run: "composer install --no-interaction --no-progress"
 
       - name: "Checkout current HEAD as a named ref"
         run: "git checkout -b ci-run-branch"

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -15,7 +15,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "7.4"
+          - "8.0"
         operating-system:
           - "ubuntu-latest"
 

--- a/.github/workflows/run-example.yml
+++ b/.github/workflows/run-example.yml
@@ -17,7 +17,7 @@ jobs:
           - "highest"
           - "locked"
         php-version:
-          - "7.4"
+          - "8.0"
         operating-system:
           - "ubuntu-latest"
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php":                       "^7.4.7 || ~8.0.0",
+        "php":                       "~8.0.0",
         "ext-json":                  "*",
         "composer-plugin-api":       "^2.0.0",
         "ocramius/package-versions": "^2.1.0",

--- a/test/e2e/SimulatedInstallationTest.php
+++ b/test/e2e/SimulatedInstallationTest.php
@@ -13,7 +13,7 @@ final class SimulatedInstallationTest extends TestCase
 
     protected function tearDown(): void
     {
-        (new Process([__DIR__ . '/../../vendor/bin/composer', 'install', '--ignore-platform-req=php'], __DIR__ . '/../..'))->mustRun();
+        (new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], __DIR__ . '/../..'))->mustRun();
 
         parent::tearDown();
     }
@@ -22,7 +22,7 @@ final class SimulatedInstallationTest extends TestCase
     {
         $this->repository = GenerateRepository::generateRepository();
 
-        $command = (new Process([__DIR__ . '/../../vendor/bin/composer', 'install', '--ignore-platform-req=php'], $this->repository))
+        $command = (new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], $this->repository))
             ->mustRun();
 
         $output = $command->getOutput();
@@ -37,7 +37,7 @@ final class SimulatedInstallationTest extends TestCase
     {
         $this->repository = GenerateRepository::generateRepository('test/repository-not-depending-on-type-checks');
 
-        $command = (new Process([__DIR__ . '/../../vendor/bin/composer', 'install', '--ignore-platform-req=php'], $this->repository))
+        $command = (new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], $this->repository))
             ->mustRun();
 
         $output = $command->getOutput();
@@ -52,7 +52,7 @@ final class SimulatedInstallationTest extends TestCase
     {
         $this->repository = GenerateRepository::generateRepository('test/repository-depending-on-type-checks');
 
-        $command = new Process([__DIR__ . '/../../vendor/bin/composer', 'install', '--ignore-platform-req=php'], $this->repository);
+        $command = new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], $this->repository);
 
         $command->run();
 
@@ -77,7 +77,7 @@ final class SimulatedInstallationTest extends TestCase
     {
         $this->repository = GenerateRepository::generateRepository('test/repository-indirectly-depending-on-type-checks');
 
-        $command = new Process([__DIR__ . '/../../vendor/bin/composer', 'install', '--ignore-platform-req=php'], $this->repository);
+        $command = new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], $this->repository);
 
         $command->run();
 
@@ -107,7 +107,7 @@ final class SimulatedInstallationTest extends TestCase
             'test/repository-not-depending-on-type-checks',
         );
 
-        $command = new Process([__DIR__ . '/../../vendor/bin/composer', 'install', '--ignore-platform-req=php'], $this->repository);
+        $command = new Process([__DIR__ . '/../../vendor/bin/composer', 'install'], $this->repository);
 
         $command->run();
 


### PR DESCRIPTION
In #96, we merged support for PHP.

That works, but it leads to downstream issues when trying to upgrade/downstream dependencies when checking for compatibility issues: in CI runs.

Therefore, here we drop PHP 7 support and lock onto PHP 8 (only), which is healthier for the overall support/maintenance of this package.