### PR TITLE
Fix issues that prevent dependabot updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "ocramius/package-versions": "^2.3.0",
         "vimeo/psalm":               "^4.4.1"
     },
+    "conflict": {
+        "vimeo/psalm": "4.6.3"
+    },
     "require-dev": {
         "composer/composer":        "^2.0.9",
         "doctrine/coding-standard": "^8.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb536aed0815482d92b324f5558a4e47",
+    "content-hash": "47ad96cf34ac0d7c4c6bb014c6d98eb8",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1851,12 +1851,12 @@
             "version": "1.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
@@ -1894,8 +1894,8 @@
                 "validate"
             ],
             "support": {
-                "issues": "https://github.com/webmozart/assert/issues",
-                "source": "https://github.com/webmozart/assert/tree/master"
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
             },
             "time": "2020-07-08T17:02:28+00:00"
         },

--- a/test/e2e/SimulatedInstallationTest.php
+++ b/test/e2e/SimulatedInstallationTest.php
@@ -56,7 +56,7 @@ final class SimulatedInstallationTest extends TestCase
 
         $command->run();
 
-        self::assertSame(1, $command->getExitCode());
+        self::assertGreaterThan(0, $command->getExitCode());
 
         $output = $command->getOutput();
 
@@ -81,7 +81,7 @@ final class SimulatedInstallationTest extends TestCase
 
         $command->run();
 
-        self::assertSame(1, $command->getExitCode());
+        self::assertGreaterThan(0, $command->getExitCode());
 
         $output = $command->getOutput();
 
@@ -111,7 +111,7 @@ final class SimulatedInstallationTest extends TestCase
 
         $command->run();
 
-        self::assertSame(1, $command->getExitCode());
+        self::assertGreaterThan(0, $command->getExitCode());
 
         $output = $command->getOutput();
 

--- a/test/e2e/SimulatedInstallationTest.php
+++ b/test/e2e/SimulatedInstallationTest.php
@@ -64,8 +64,8 @@ final class SimulatedInstallationTest extends TestCase
         self::assertStringContainsString(' - test/repository-depending-on-type-checks', $output);
         self::assertStringContainsString(' - - Test\\RepositoryDependingOnTypeChecks\\', $output);
         self::assertStringContainsString('1 errors', $output);
-        self::assertStringContainsString(
-            'Argument 1 of Test\\RepositoryDependingOnTypeChecks\\SomeClass::aMethod expects string, int(123) provided',
+        self::assertMatchesRegularExpression(
+            '@Argument 1 of Test\\\\RepositoryDependingOnTypeChecks\\\\SomeClass::aMethod expects string, (int\(123\)|123) provided@',
             $output
         );
 
@@ -89,8 +89,8 @@ final class SimulatedInstallationTest extends TestCase
         self::assertStringContainsString(' - test/repository-depending-on-type-checks', $output);
         self::assertStringContainsString(' - - Test\\RepositoryDependingOnTypeChecks\\', $output);
         self::assertStringContainsString('1 errors', $output);
-        self::assertStringContainsString(
-            'Argument 1 of Test\\RepositoryDependingOnTypeChecks\\SomeClass::aMethod expects string, int(123) provided',
+        self::assertMatchesRegularExpression(
+            '@Argument 1 of Test\\\\RepositoryDependingOnTypeChecks\\\\SomeClass::aMethod expects string, (int\(123\)|123) provided@',
             $output
         );
 
@@ -119,8 +119,8 @@ final class SimulatedInstallationTest extends TestCase
         self::assertStringContainsString(' - test/repository-depending-on-type-checks', $output);
         self::assertStringContainsString(' - - Test\\RepositoryDependingOnTypeChecks\\', $output);
         self::assertStringContainsString('1 errors', $output);
-        self::assertStringContainsString(
-            'Argument 1 of Test\\RepositoryDependingOnTypeChecks\\SomeClass::aMethod expects string, int(123) provided',
+        self::assertMatchesRegularExpression(
+            '@Argument 1 of Test\\\\RepositoryDependingOnTypeChecks\\\\SomeClass::aMethod expects string, (int\(123\)|123) provided@',
             $output
         );
 


### PR DESCRIPTION
Rationale for each separate change is provided in a corresponding commit message.

This should unblock automatic updates that were failing because of Psalm / tests issues.